### PR TITLE
Improve HTTP Request Error Logging

### DIFF
--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -5,6 +5,8 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
+
+using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
 
@@ -72,12 +74,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Discord
                     .CreateClient(NamedClient.Default)
                     .PostAsync(new Uri(options.WebhookUri), content)
                     .ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode)
-                {
-                    var responseStr = await response.Content.ReadAsStringAsync()
-                        .ConfigureAwait(false);
-                    _logger.LogWarning("Error sending notification: {Response}", responseStr);
-                }
+                await response.LogIfFailed(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -5,7 +5,6 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
@@ -74,7 +73,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Discord
                     .CreateClient(NamedClient.Default)
                     .PostAsync(new Uri(options.WebhookUri), content)
                     .ConfigureAwait(false);
-                await response.LogIfFailed(_logger).ConfigureAwait(false);
+                await response.LogIfFailedAsync(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Generic/GenericClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Generic/GenericClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
@@ -83,12 +84,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Generic
                     .CreateClient(NamedClient.Default)
                     .SendAsync(httpRequestMessage)
                     .ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode)
-                {
-                    var responseStr = await response.Content.ReadAsStringAsync()
-                        .ConfigureAwait(false);
-                    _logger.LogWarning("Error sending notification: {Response}", responseStr);
-                }
+                await response.LogIfFailedAsync(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Gotify/GotifyClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Gotify/GotifyClient.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
@@ -59,7 +58,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Gotify
                     .CreateClient(NamedClient.Default)
                     .PostAsync(new Uri(options.WebhookUri.TrimEnd() + $"/message?token={options.Token}"), content)
                     .ConfigureAwait(false);
-                await response.LogIfFailed(_logger).ConfigureAwait(false);
+                await response.LogIfFailedAsync(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Gotify/GotifyClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Gotify/GotifyClient.cs
@@ -4,6 +4,8 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
+
+using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
 
@@ -57,12 +59,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Gotify
                     .CreateClient(NamedClient.Default)
                     .PostAsync(new Uri(options.WebhookUri.TrimEnd() + $"/message?token={options.Token}"), content)
                     .ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode)
-                {
-                    var responseStr = await response.Content.ReadAsStringAsync()
-                        .ConfigureAwait(false);
-                    _logger.LogWarning("Error sending notification: {Response}", responseStr);
-                }
+                await response.LogIfFailed(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Pushbullet/PushbulletClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Pushbullet/PushbulletClient.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
@@ -61,7 +60,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Pushbullet
                     .CreateClient(NamedClient.Default)
                     .SendAsync(requestOptions)
                     .ConfigureAwait(false);
-                await response.LogIfFailed(_logger).ConfigureAwait(false);
+                await response.LogIfFailedAsync(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Pushbullet/PushbulletClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Pushbullet/PushbulletClient.cs
@@ -4,6 +4,8 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
+
+using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
 
@@ -59,12 +61,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Pushbullet
                     .CreateClient(NamedClient.Default)
                     .SendAsync(requestOptions)
                     .ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode)
-                {
-                    var responseStr = await response.Content.ReadAsStringAsync()
-                        .ConfigureAwait(false);
-                    _logger.LogWarning("Error sending notification: {Response}", responseStr);
-                }
+                await response.LogIfFailed(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Pushover/PushoverClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Pushover/PushoverClient.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
@@ -83,7 +82,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Pushover
                     .CreateClient(NamedClient.Default)
                     .PostAsync(string.IsNullOrEmpty(options.WebhookUri) ? PushoverOption.ApiUrl : new Uri(options.WebhookUri), content)
                     .ConfigureAwait(false);
-                await response.LogIfFailed(_logger).ConfigureAwait(false);
+                await response.LogIfFailedAsync(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Pushover/PushoverClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Pushover/PushoverClient.cs
@@ -4,6 +4,8 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
+
+using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
 
@@ -81,12 +83,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Pushover
                     .CreateClient(NamedClient.Default)
                     .PostAsync(string.IsNullOrEmpty(options.WebhookUri) ? PushoverOption.ApiUrl : new Uri(options.WebhookUri), content)
                     .ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode)
-                {
-                    var responseStr = await response.Content.ReadAsStringAsync()
-                        .ConfigureAwait(false);
-                    _logger.LogWarning("Error sending notification: {Response}", responseStr);
-                }
+                await response.LogIfFailed(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Slack/SlackClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Slack/SlackClient.cs
@@ -4,6 +4,8 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
+
+using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
 
@@ -57,12 +59,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Slack
                     .CreateClient(NamedClient.Default)
                     .PostAsync(new Uri(options.WebhookUri), content)
                     .ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode)
-                {
-                    var responseStr = await response.Content.ReadAsStringAsync()
-                        .ConfigureAwait(false);
-                    _logger.LogWarning("Error sending notification: {Response}", responseStr);
-                }
+                await response.LogIfFailed(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Slack/SlackClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Slack/SlackClient.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
-
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
@@ -59,7 +58,7 @@ namespace Jellyfin.Plugin.Webhook.Destinations.Slack
                     .CreateClient(NamedClient.Default)
                     .PostAsync(new Uri(options.WebhookUri), content)
                     .ConfigureAwait(false);
-                await response.LogIfFailed(_logger).ConfigureAwait(false);
+                await response.LogIfFailedAsync(_logger).ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {

--- a/Jellyfin.Plugin.Webhook/Extensions/HttpResponseMessageExtensions.cs
+++ b/Jellyfin.Plugin.Webhook/Extensions/HttpResponseMessageExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -19,7 +15,7 @@ namespace Jellyfin.Plugin.Webhook.Extensions
         /// <param name="response">The HTTP response to log if failed.</param>
         /// <param name="logger">The logger to use to log the warning.</param>
         /// <returns>A task representing the async operation.</returns>
-        public static async Task LogIfFailed(this HttpResponseMessage response, ILogger logger)
+        public static async Task LogIfFailedAsync(this HttpResponseMessage response, ILogger logger)
         {
             // Don't log anything for successful responses
             if (response.IsSuccessStatusCode)

--- a/Jellyfin.Plugin.Webhook/Extensions/HttpResponseMessageExtensions.cs
+++ b/Jellyfin.Plugin.Webhook/Extensions/HttpResponseMessageExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Webhook.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="HttpResponseMessage"/>.
+    /// </summary>
+    public static class HttpResponseMessageExtensions
+    {
+        /// <summary>
+        /// Log a warning message if the <paramref name="response"/> contains an error status code.
+        /// </summary>
+        /// <param name="response">The HTTP response to log if failed.</param>
+        /// <param name="logger">The logger to use to log the warning.</param>
+        /// <returns>A task representing the async operation.</returns>
+        public static async Task LogIfFailed(this HttpResponseMessage response, ILogger logger)
+        {
+            // Don't log anything for successful responses
+            if (response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            // Log the request that caused the failed response, if available
+            var request = response.RequestMessage;
+            if (request is not null)
+            {
+                var requestStr = request.Content is not null
+                    ? await request.Content.ReadAsStringAsync().ConfigureAwait(false)
+                    : "<empty request body>";
+                logger.LogWarning("Notification failed with {Method} request to {Url}: {Content}", request.Method, request.RequestUri, requestStr);
+            }
+
+            // Log the response
+            var responseStr = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            logger.LogWarning("Notification failed with response status code {StatusCode}: {Content}", response.StatusCode, responseStr);
+        }
+    }
+}


### PR DESCRIPTION
The existing behavior for a failed HTTP request is to only log the response content. 

This PR adds logic to also log the request URL and content, as well as the response code.