### PR TITLE
ci: set ABI version and more repo automation

### DIFF
--- a/.github/workflows/command-dispatch.yaml
+++ b/.github/workflows/command-dispatch.yaml
@@ -1,0 +1,21 @@
+# Allows for the definition of PR and Issue /commands
+name: Slash Command Dispatcher
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  launcher:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.JF_BOT_TOKEN }}
+          permission: write
+          issue-type: pull-request
+          commands: |-
+            rebase
+            update-prep

--- a/.github/workflows/command-rebase.yaml
+++ b/.github/workflows/command-rebase.yaml
@@ -24,7 +24,7 @@ jobs:
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray
 
-      - name: Add Failiur Reaction
+      - name: Add Failure Reaction
         if: ${{ steps.rebase.outputs.rebased-count == 0 || failure() }}
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/.github/workflows/command-rebase.yaml
+++ b/.github/workflows/command-rebase.yaml
@@ -1,0 +1,34 @@
+name: PR Rebase Command
+
+on:
+  repository_dispatch:
+    types:
+      - rebase-command
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rebase PR
+        uses: peter-evans/rebase@v1
+        id: rebase
+        with:
+          head: ${{ github.event.client_payload.pull_request.head.label }}
+
+      - name: Add Success Reaction
+        if: ${{ steps.rebase.outputs.rebased-count == 1 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.JF_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray
+
+      - name: Add Failiur Reaction
+        if: ${{ steps.rebase.outputs.rebased-count == 0 || failure() }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.JF_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: confused, -1

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
   repository_dispatch:
     types:
-      - rebase-command
+      - update-prep-command
 
 jobs:
   update_release_draft:

--- a/.github/workflows/update-release-draft.yml
+++ b/.github/workflows/update-release-draft.yml
@@ -5,7 +5,12 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - build.yaml
   workflow_dispatch:
+  repository_dispatch:
+    types:
+      - rebase-command
 
 jobs:
   update_release_draft:
@@ -23,9 +28,9 @@ jobs:
       - name: Setup YQ
         uses: chrisdickinson/setup-yq@latest
         with:
-          yq-version: v4.9.6
+          yq-version: v4.12.2
 
-      - name: Parse changelog
+      - name: Set-up Environment
         run: |
           TAG="${{ steps.draft.outputs.tag_name }}"
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
@@ -41,16 +46,22 @@ jobs:
           cat cl.md >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
+          echo "HAS_CHANGES=$(grep -qie 'No changes$' cl.md && echo false || echo true)" >> $GITHUB_ENV
           rm cl.md
 
-      - name: Checkout repository
+          echo "ABI_VERSION=$(curl -s https://api.jellyfin.org/openapi/jellyfin-openapi-stable.json | jq -r '.info.version').0" >> $GITHUB_ENV
+
+      - name: Checkout Repository
+        if: ${{ env.HAS_CHANGES == 'true' }}
         uses: actions/checkout@v2
 
       - name: Update build.yaml
+        if: ${{ env.HAS_CHANGES == 'true' }}
         run: |
-          yq eval '.version = env(VERSION) | .changelog = strenv(CHANGELOG) | .changelog style="literal"' -i build.yaml
+          yq eval '.version = env(VERSION) | .targetAbi = env(ABI_VERSION) | .changelog = strenv(CHANGELOG) | .changelog style="literal"' -i build.yaml
 
       - name: Commit Changes
+        if: ${{ env.HAS_CHANGES == 'true' }}
         run: |
           git config user.name "jellyfin-bot"
           git config user.email "team@jellyfin.org"
@@ -59,6 +70,7 @@ jobs:
           git push -f origin prepare-${{ env.VERSION }}
 
       - name: Create or Update PR
+        if: ${{ env.HAS_CHANGES == 'true' }}
         uses: k3rnels-actions/pr-update@v1
         with:
           token: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
### Description

This PR aims to improve the plugin CI and prevent further situations where plugin update on servers that don't have the correct ABI version.

### Changes

* add Slash Command Dispatcher workflow
* add slash-rebase command workflow
* add ABI version update to release-drafter workflow
* fix release-drafter workflow running after merging the prepare PR

### Issues

* n/a
