### PR TITLE
fix: wrong name in ci workflows

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -10,5 +10,5 @@ jobs:
   call:
     uses: jellyfin/jellyfin-meta-plugins/.github/workflows/bump-version.yaml@master
     with:
-      csproj-name: Jellyfin.Plugin.Template
+      csproj-name: Jellyfin.Plugin.Webhook
       is-unstable: ${{ github.event.release.prerelease }}

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -15,6 +15,6 @@ jobs:
   call:
     uses: jellyfin/jellyfin-meta-plugins/.github/workflows/changelog.yaml@master
     with:
-      repository-name: h1dden-da3m0n/jeff-automation-test
+      repository-name: jellyfin/jellyfin-plugin-webhook
     secrets:
       token: ${{ secrets.JF_BOT_TOKEN }}

--- a/Jellyfin.Plugin.Webhook/Jellyfin.Plugin.Webhook.csproj
+++ b/Jellyfin.Plugin.Webhook/Jellyfin.Plugin.Webhook.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <FileVersion>2.0.0.0</FileVersion>
+        <AssemblyVersion>11.0.0.0</AssemblyVersion>
+        <FileVersion>11.0.0.0</FileVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "Webhook"
 guid: "71552A5A-5C5C-4350-A2AE-EBE451A30173"
 imageUrl: "https://repo.jellyfin.org/releases/plugin/images/jellyfin-plugin-webhook.png"
-version: "10"
+version: "11"
 targetAbi: "10.8.0.0"
 framework: "net6.0"
 owner: "jellyfin"


### PR DESCRIPTION
well, these slipped through the review

This also bumps the versions, as the new workflow will only bump them after a release event and no longer as part of the changelog workflow.