### PR TITLE
Add handlebar templates for Pushover

### DIFF
--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/Generic.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/Generic.handlebars
@@ -1,0 +1,11 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    "message": "{{Name}}"
+}

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/ItemAdded.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/ItemAdded.handlebars
@@ -1,4 +1,4 @@
-﻿{
+{
     "token": "{{Token}}",
     "user": "{{UserToken}}",
     "device": "{{Device}}",

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/PlaybackStart.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/PlaybackStart.handlebars
@@ -1,0 +1,13 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    {{#if_equals ItemType 'Episode'}}
+        "message": "{{NotificationUsername}} started playback of {{{SeriesName}}} S{{SeasonNumber00}}E{{EpisodeNumber00}} {{{Name}}} on {{DeviceName}} with {{ClientName}}"
+    {{/if_equals}}
+}

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/PlaybackStop.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/PlaybackStop.handlebars
@@ -1,0 +1,13 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    {{#if_equals ItemType 'Episode'}}
+        "message": "{{NotificationUsername}} stopped playback of {{{SeriesName}}} S{{SeasonNumber00}}E{{EpisodeNumber00}} {{{Name}}} on {{DeviceName}} with {{ClientName}}"
+    {{/if_equals}}
+}

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/PluginInstalling.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/PluginInstalling.handlebars
@@ -1,0 +1,11 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    "message": "Installing plugin {{PluginName}} version {{PluginVersion}}..."
+}

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/UserCreated.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/UserCreated.handlebars
@@ -1,0 +1,11 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    "message": "A new user '{{NotificationUsername}}' was created on your server {{ServerName}}"
+}

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/UserDeleted.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/UserDeleted.handlebars
@@ -1,0 +1,11 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    "message": "The user '{{NotificationUsername}}' has been deleted on {{ServerName}}"
+}

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/UserLockedOut.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/UserLockedOut.handlebars
@@ -1,0 +1,11 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    "message": "The user '{{NotificationUsername}}' has been locked out because they exceeded the allowed incorrect login attempts."
+}

--- a/Jellyfin.Plugin.Webhook/Templates/Pushover/UserPasswordChanged.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Pushover/UserPasswordChanged.handlebars
@@ -1,0 +1,11 @@
+{
+    "token": "{{Token}}",
+    "user": "{{UserToken}}",
+    "device": "{{Device}}",
+    "title": "{{{Title}}}",
+    "url": "{{ServerUrl}}/web/index.html#!/details?id={{ItemId}}&serverId={{ServerId}}",
+    "url_title": "{{{MessageUrlTitle}}}",
+    "priority": {{MessagePriority}},
+    "sound": "{{NotificationSound}}",
+    "message": "The password for the user '{{NotificationUsername}}' has been changed"
+}


### PR DESCRIPTION
The Pushover template does only work for the item added notification type.
Since there is a ton of other notifications, that people might be interested in, I created templates for them.

For some reason, I was not able to produce notifications for the following types:
- Authentication Success
- Authentication Failure
- Plugin installed
- Pending restart
- User updated

For this reason, I have not included them here in this pull request.