### PR TITLE
Support for SeriesId

### DIFF
--- a/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
@@ -79,6 +79,11 @@ public static class DataObjectHelpers
                     dataObject["Year"] = season.Series.ProductionYear;
                 }
 
+                if (season.Series?.Id is not null)
+                {
+                    dataObject["SeriesId"] = season.Series.Id;
+                }
+
                 if (season.IndexNumber is not null)
                 {
                     dataObject["SeasonNumber"] = season.IndexNumber;
@@ -91,6 +96,11 @@ public static class DataObjectHelpers
                 if (!string.IsNullOrEmpty(episode.Series?.Name))
                 {
                     dataObject["SeriesName"] = episode.Series.Name.Escape();
+                }
+
+                if (episode.Series?.Id is not null)
+                {
+                    dataObject["SeriesId"] = episode.Series.Id;
                 }
 
                 if (!episode.SeasonId.Equals(default))


### PR DESCRIPTION
Fixes:  https://github.com/jellyfin/jellyfin-plugin-webhook/issues/143 & partly https://github.com/jellyfin/jellyfin-plugin-webhook/issues/147 & https://github.com/jellyfin/jellyfin-plugin-webhook/issues/172

With this you will be able to get `SeriesId` which you can use to create posters of the show instead of `ItemId` which gives you a backdrop of the Episode.