### PR TITLE
Implement option to skip sending webhooks with an empty message body

### DIFF
--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
@@ -116,6 +116,10 @@
                 <input is="emby-checkbox" type="checkbox" data-name="chkSendAllProperties"/>
                 <span>Send All Properties (ignores template)</span>
             </label>
+            <label class="checkboxContainer">
+                <input is="emby-checkbox" type="checkbox" data-name="chkSkipEmptyMessageBody"/>
+                <span>Do not send when message body is empty</span>
+            </label>
         </div>
         <div class="inputContainer">
             <label>Template:</label>

--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
@@ -162,6 +162,7 @@
                 element.querySelector("[data-name=txtWebhookName]").value = config.WebhookName || "";
                 element.querySelector("[data-name=txtWebhookUri]").value = config.WebhookUri || "";
                 element.querySelector("[data-name=chkSendAllProperties]").checked = config.SendAllProperties || false;
+                element.querySelector("[data-name=chkSkipEmptyMessageBody]").checked = config.SkipEmptyMessageBody || false;
                 element.querySelector("[data-name=txtTemplate]").value = Webhook.atou(config.Template || "");
 
                 const notificationTypeContainer = element.querySelector("[data-name=notificationTypeContainer]");
@@ -182,6 +183,7 @@
                 config.WebhookName = element.querySelector("[data-name=txtWebhookName]").value || "";
                 config.WebhookUri = element.querySelector("[data-name=txtWebhookUri]").value || "";
                 config.SendAllProperties = element.querySelector("[data-name=chkSendAllProperties]").checked || false;
+                config.SkipEmptyMessageBody = element.querySelector("[data-name=chkSkipEmptyMessageBody]").checked || false;
                 config.Template = Webhook.utoa(element.querySelector("[data-name=txtTemplate]").value || "");
 
                 config.NotificationTypes = [];

--- a/Jellyfin.Plugin.Webhook/Destinations/BaseClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/BaseClient.cs
@@ -36,4 +36,25 @@ public class BaseClient
 
         return true;
     }
+
+    /// <summary>
+    /// Determines whether the client should send the webhook with the given message body.
+    /// </summary>
+    /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+    /// <param name="option">The sender option.</param>
+    /// <param name="body">The message body.</param>
+    /// <returns>Whether the client should send the webhook.</returns>
+    protected bool SendMessageBody(
+        ILogger logger,
+        BaseOption option,
+        string body)
+    {
+        if (option.SkipEmptyMessageBody && string.IsNullOrWhiteSpace(body))
+        {
+            logger.LogDebug("Skip sending empty message body");
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
@@ -68,6 +68,11 @@ public abstract class BaseOption
     public bool SendAllProperties { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to skip sending an empty message body.
+    /// </summary>
+    public bool SkipEmptyMessageBody { get; set; }
+
+    /// <summary>
     /// Gets or sets the handlebars template.
     /// </summary>
     public string? Template { get; set; }

--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -64,6 +64,11 @@ public class DiscordClient : BaseClient, IWebhookClient<DiscordOption>
             }
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             _logger.LogDebug("SendAsync Body: {@Body}", body);
             using var content = new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
             using var response = await _httpClientFactory

--- a/Jellyfin.Plugin.Webhook/Destinations/Generic/GenericClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Generic/GenericClient.cs
@@ -53,6 +53,11 @@ public class GenericClient : BaseClient, IWebhookClient<GenericOption>
             }
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             _logger.LogDebug("SendAsync Body: {@Body}", body);
             using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, option.WebhookUri);
             var contentType = MediaTypeNames.Text.Plain;

--- a/Jellyfin.Plugin.Webhook/Destinations/GenericForm/GenericFormClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/GenericForm/GenericFormClient.cs
@@ -50,6 +50,11 @@ public class GenericFormClient : BaseClient, IWebhookClient<GenericFormOption>
             }
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             var dictionaryBody = JsonSerializer.Deserialize<Dictionary<string, string>>(body);
             if (dictionaryBody is null)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Gotify/GotifyClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Gotify/GotifyClient.cs
@@ -48,6 +48,11 @@ public class GotifyClient : BaseClient, IWebhookClient<GotifyOption>
             data["Priority"] = option.Priority;
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             _logger.LogDebug("SendAsync Body: {@Body}", body);
             using var content = new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
             using var response = await _httpClientFactory

--- a/Jellyfin.Plugin.Webhook/Destinations/Mqtt/MqttClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Mqtt/MqttClient.cs
@@ -36,6 +36,11 @@ public class MqttClient : BaseClient, IWebhookClient<MqttOption>
             }
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             var client = _mqttClients.GetClient(option.Guid);
             if (client?.IsConnected != true)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Pushbullet/PushbulletClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Pushbullet/PushbulletClient.cs
@@ -45,6 +45,11 @@ public class PushbulletClient : BaseClient, IWebhookClient<PushbulletOption>
             data["PushbulletChannel"] = option.Channel;
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             _logger.LogDebug("SendAsync Body: {@Body}", body);
 
             using var requestOptions = new HttpRequestMessage(HttpMethod.Post, string.IsNullOrEmpty(option.WebhookUri) ? PushbulletOption.ApiUrl : option.WebhookUri);

--- a/Jellyfin.Plugin.Webhook/Destinations/Pushover/PushoverClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Pushover/PushoverClient.cs
@@ -72,6 +72,11 @@ public class PushoverClient : BaseClient, IWebhookClient<PushoverOption>
             }
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             _logger.LogDebug("SendAsync Body: {@Body}", body);
             using var content = new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
             using var response = await _httpClientFactory

--- a/Jellyfin.Plugin.Webhook/Destinations/Slack/SlackClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Slack/SlackClient.cs
@@ -49,6 +49,11 @@ public class SlackClient : BaseClient, IWebhookClient<SlackOption>
             data["SlackIconUrl"] = option.IconUrl;
 
             var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
+            {
+                return;
+            }
+
             _logger.LogDebug("SendAsync Body: {@Body}", body);
             using var content = new StringContent(body, Encoding.UTF8, MediaTypeNames.Application.Json);
             using var response = await _httpClientFactory

--- a/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
@@ -37,10 +37,13 @@ public class SmtpClient : BaseClient, IWebhookClient<SmtpOption>
             message.To.Add(new MailboxAddress(option.ReceiverAddress, option.ReceiverAddress));
 
             message.Subject = option.GetCompiledSubjectTemplate()(data);
-            message.Body = new TextPart(option.IsHtml ? "html" : "plain")
+            var body = option.GetMessageBody(data);
+            if (!SendMessageBody(_logger, option, body))
             {
-                Text = option.GetMessageBody(data)
-            };
+                return;
+            }
+
+            message.Body = new TextPart(option.IsHtml ? "html" : "plain") { Text = body };
 
             using var smtpClient = new MailKit.Net.Smtp.SmtpClient();
             await smtpClient.ConnectAsync(option.SmtpServer, option.SmtpPort, option.UseSsl)


### PR DESCRIPTION
I added a new option to skip sending the webhook when the message body would be empty. This could be useful for example when one would like to send data only when a selected client is affected.

The feature is backwards compatible as it is turned off by default.

It should work the way it is implemented in this pr. However, the implementation required adding a check to every client and will require adding it to every new one in the future as well.

--------------------

As an alternative, it would be possible to split every client's `SendAsync()` into two sections: one which prepares the `data` (adds more fields, etc.) and an other one which handles the sending and does not change the `data` anymore. As far as I see, all clients can be split in this manner. This way all common checks could be done in a base class (`BaseClient`) function, something like the very rudimentary code snippet below.

```csharp
public async Task SendAsync(BaseOption option, Dictionary<string, object> data)
{
    if (!SendWebhook(_logger, option, data))
    {
        return;
    }

    PrepareData(_logger, option, data); // function every client can implement, could have a "passthrough" as default

    var body = option.GetMessageBody(data);
    if (!SendMessageBody(_logger, option, body))
    {
        return;
    }

    SendAsyncWebhook(_logger, option, data, body); // function every client must implement
}
```

To be honest, I'm not sure how to handle the logger in the base class (yet) as these are my first lines of C# code.

Additionally, I'm also not sure whether a big change like this would be something you'd like to see, so I went with the simple solution as a first implementation to get some feedback.