### PR TITLE
fix: remove extra curly braces from templates

### DIFF
--- a/Jellyfin.Plugin.Webhook/Templates/Discord.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Discord.handlebars
@@ -1,7 +1,7 @@
 ﻿{
     "content": "{{MentionType}}",
     "avatar_url": "{{AvatarUrl}}",
-    "username": "{{{BotUsername}}}",
+    "username": "{{BotUsername}}",
     "embeds": [
         {
             "color": "{{EmbedColor}}",

--- a/Jellyfin.Plugin.Webhook/Templates/Discord/ItemAdded.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Discord/ItemAdded.handlebars
@@ -1,7 +1,7 @@
 {
     "content": "{{MentionType}}",
     "avatar_url": "{{AvatarUrl}}",
-    "username": "{{{BotUsername}}}",
+    "username": "{{BotUsername}}",
     "embeds": [
         {   
             "author": {

--- a/Jellyfin.Plugin.Webhook/Templates/Discord/UserLockedOut.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Discord/UserLockedOut.handlebars
@@ -1,7 +1,7 @@
 {
     "content": "{{MentionType}}",
     "avatar_url": "{{AvatarUrl}}",
-    "username": "{{{BotUsername}}}",
+    "username": "{{BotUsername}}",
     "embeds": [
         {   
             "author": {


### PR DESCRIPTION
I noticed that there were some extra curly braces in the template files when I was setting up my own notifications. These should work, unless the intent was to have the name formatted as `{MyBotName}` in discord. 