### PR TITLE
Implement option to trim leading/trailing whitespace from message body

### DIFF
--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
@@ -116,6 +116,10 @@
                 <input is="emby-checkbox" type="checkbox" data-name="chkSendAllProperties"/>
                 <span>Send All Properties (ignores template)</span>
             </label>
+            <label class="checkboxContainer">
+                <input is="emby-checkbox" type="checkbox" data-name="chkTrimWhitespace"/>
+                <span>Trim leading and trailing whitespace from message body before sending</span>
+            </label>
         </div>
         <div class="inputContainer">
             <label>Template:</label>

--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
@@ -162,6 +162,7 @@
                 element.querySelector("[data-name=txtWebhookName]").value = config.WebhookName || "";
                 element.querySelector("[data-name=txtWebhookUri]").value = config.WebhookUri || "";
                 element.querySelector("[data-name=chkSendAllProperties]").checked = config.SendAllProperties || false;
+                element.querySelector("[data-name=chkTrimWhitespace]").checked = config.TrimWhitespace || false;
                 element.querySelector("[data-name=txtTemplate]").value = Webhook.atou(config.Template || "");
 
                 const notificationTypeContainer = element.querySelector("[data-name=notificationTypeContainer]");
@@ -182,6 +183,7 @@
                 config.WebhookName = element.querySelector("[data-name=txtWebhookName]").value || "";
                 config.WebhookUri = element.querySelector("[data-name=txtWebhookUri]").value || "";
                 config.SendAllProperties = element.querySelector("[data-name=chkSendAllProperties]").checked || false;
+                config.TrimWhitespace = element.querySelector("[data-name=chkTrimWhitespace]").checked || false;
                 config.Template = Webhook.utoa(element.querySelector("[data-name=txtTemplate]").value || "");
 
                 config.NotificationTypes = [];

--- a/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
@@ -68,6 +68,11 @@ public abstract class BaseOption
     public bool SendAllProperties { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to trim the message body before sending.
+    /// </summary>
+    public bool TrimWhitespace { get; set; }
+
+    /// <summary>
     /// Gets or sets the handlebars template.
     /// </summary>
     public string? Template { get; set; }
@@ -93,8 +98,10 @@ public abstract class BaseOption
     /// <returns>The string message body.</returns>
     public string GetMessageBody(Dictionary<string, object> data)
     {
-        return SendAllProperties
+        var body = SendAllProperties
             ? JsonSerializer.Serialize(data, JsonDefaults.Options)
             : GetCompiledTemplate()(data);
+
+        return TrimWhitespace ? body.Trim() : body;
     }
 }

--- a/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
@@ -72,6 +72,7 @@ public abstract class BaseOption
     /// </summary>
     public bool TrimWhitespace { get; set; }
 
+    /// <summary>
     /// Gets or sets a value indicating whether to skip sending an empty message body.
     /// </summary>
     public bool SkipEmptyMessageBody { get; set; }


### PR DESCRIPTION
I added a new option to trim leading and trailing whitespaces from the webhook message body before sending. This is useful for example when a client expects an exact value and the webhook template is formatted multiline. It is mostly a convenience feature for template writing.

The feature is backwards compatible as it is turned off by default.