### PR TITLE
Fix discord json encoded strings

### DIFF
--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
-using System.Threading.Tasks;
 using System.Text.Json;
-using System.Linq;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
@@ -67,8 +67,7 @@ public class DiscordClient : BaseClient, IWebhookClient<DiscordOption>
 
             var escapedJsonData = data.ToDictionary(
                 kvp => kvp.Key,
-                kvp => (object)System.Text.Json.JsonSerializer.Serialize(kvp.Value)
-            );
+                kvp => (object)System.Text.Json.JsonSerializer.Serialize(kvp.Value));
 
             var body = option.GetMessageBody(escapedJsonData);
             if (!SendMessageBody(_logger, option, body))

--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -67,7 +67,7 @@ public class DiscordClient : BaseClient, IWebhookClient<DiscordOption>
 
             var escapedJsonData = data.ToDictionary(
                 kvp => kvp.Key,
-                kvp => (object)System.Text.Json.JsonSerializer.Serialize(kvp.Value));
+                kvp => (object)System.Text.Json.JsonSerializer.Serialize(kvp.Value).Trim('"'));
 
             var body = option.GetMessageBody(escapedJsonData);
             if (!SendMessageBody(_logger, option, body))

--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -6,6 +6,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
 using System.Text.Json;
+using System.Linq;
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;

--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Mime;
 using System.Text;
 using System.Threading.Tasks;
+using System.Text.Json;
 using Jellyfin.Plugin.Webhook.Extensions;
 using MediaBrowser.Common.Net;
 using Microsoft.Extensions.Logging;
@@ -63,7 +64,12 @@ public class DiscordClient : BaseClient, IWebhookClient<DiscordOption>
                 data["BotUsername"] = option.Username;
             }
 
-            var body = option.GetMessageBody(data);
+            var escapedJsonData = data.ToDictionary(
+                kvp => kvp.Key,
+                kvp => System.Text.Json.JsonSerializer.Serialize(kvp.Value)
+            );
+
+            var body = option.GetMessageBody(escapedJsonData);
             if (!SendMessageBody(_logger, option, body))
             {
                 return;

--- a/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Discord/DiscordClient.cs
@@ -67,7 +67,7 @@ public class DiscordClient : BaseClient, IWebhookClient<DiscordOption>
 
             var escapedJsonData = data.ToDictionary(
                 kvp => kvp.Key,
-                kvp => System.Text.Json.JsonSerializer.Serialize(kvp.Value)
+                kvp => (object)System.Text.Json.JsonSerializer.Serialize(kvp.Value)
             );
 
             var body = option.GetMessageBody(escapedJsonData);


### PR DESCRIPTION
The Discord webhook does not JSON encode the strings used in the handlebars template. So if a description has newlines, it results in invalid JSON, and does not correctly post to discord. As described in #217.

This pull request serializes all of the objects in the data dictionary with `System.Text.Json.JsonSerializer.Serialize` before rendering the template so that quotes and newlines are correctly escaped.

This may be necessary for other webhook clients depending on their APIs.