### PR TITLE
Make "Original Aspect Ratio" property available to WebHooks

### DIFF
--- a/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
@@ -76,6 +76,11 @@ public static class DataObjectHelpers
             dataObject["Genres"] = string.Join(", ", item.Genres);
         }
 
+        if (item is IHasAspectRatio aspectRatioItem && !string.IsNullOrEmpty(aspectRatioItem.AspectRatio))
+        {
+            dataObject["AspectRatio"] = aspectRatioItem.AspectRatio;
+        }
+
         switch (item)
         {
             case Season season:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ See [Templates](Jellyfin.Plugin.Webhook/Templates) for sample templates.
         - The media runtime, in [Ticks](https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks)
     - RunTime
         - The media runtime, as `hh:mm:ss`
+    - AspectRatio
+        - Item original aspect ratio 
 
 
 - Playback


### PR DESCRIPTION
This property can be populated with a user-defined aspect ratio when the video file's aspect ratio does not match the content's aspect ratio.  This is a common occurrence when video contains encoded black bars (eg UHD blu-ray content).  The "original aspect ratio" is particularly useful in webhooks as it can be used to configure projector lens memory and/or masking systems.