### PR TITLE
Allow smtp connection without SSL

### DIFF
--- a/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MailKit.Security;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MimeKit;
 
 namespace Jellyfin.Plugin.Webhook.Destinations.Smtp;

--- a/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
@@ -46,7 +46,8 @@ public class SmtpClient : BaseClient, IWebhookClient<SmtpOption>
             message.Body = new TextPart(option.IsHtml ? "html" : "plain") { Text = body };
 
             using var smtpClient = new MailKit.Net.Smtp.SmtpClient();
-            await smtpClient.ConnectAsync(option.SmtpServer, option.SmtpPort, option.UseSsl)
+            var secureSocketOptions = option.UseSsl ? SecureSocketOptions.Auto : SecureSocketOptions.None;
+            await smtpClient.ConnectAsync(option.SmtpServer, option.SmtpPort, secureSocketOptions)
                 .ConfigureAwait(false);
             if (option.UseCredentials)
             {

--- a/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
@@ -48,7 +48,7 @@ public class SmtpClient : BaseClient, IWebhookClient<SmtpOption>
             message.Body = new TextPart(option.IsHtml ? "html" : "plain") { Text = body };
 
             using var smtpClient = new MailKit.Net.Smtp.SmtpClient();
-            var secureSocketOptions = option.UseSsl ? SecureSocketOptions.Auto : SecureSocketOptions.None;
+            var secureSocketOptions = option.UseSsl ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.None;
             await smtpClient.ConnectAsync(option.SmtpServer, option.SmtpPort, secureSocketOptions)
                 .ConfigureAwait(false);
             if (option.UseCredentials)


### PR DESCRIPTION
Per MailKit documentation:

> useSsl argument only controls whether or not the client makes an SSL-wrapped connection. In other words, even if the useSsl parameter is false, SSL/TLS may still be used if the mail server supports the STARTTLS extension.  To disable all use of SSL/TLS, use the ConnectAsync(string, int, MailKit.Security.SecureSocketOptions, System.Threading.CancellationToken) overload with a value of SecureSocketOptions.None instead.

fix #120, fix #226 