### PR TITLE
ntfy.sh: Template Optimizations Pt. 3

### DIFF
--- a/Jellyfin.Plugin.Webhook/Templates/Ntfy.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Ntfy.handlebars
@@ -18,14 +18,14 @@
         "actions": [{ "action": "view", "label": "Visit Jellyfin", "url": "{{{ServerUrl}}}web/#/details?id={{ItemId}}" }],
             {{#if_equals ItemType 'Audio'}}
                 "title": "{{{NotificationUsername}}} | Playback started: {{{Artist}}} - {{{Name}}} ({{Year}})",
-                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- Action:** Playback started\n**- Play Method:** {{{PlayMethod}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Artist:** {{{Artist}}}\n**- Track:** {{{Name}}}\n**- Album:** {{{Album}}} ({{Year}})\n**- Runtime:** {{RunTime}}"
+                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Action:** Playback started\n**- Play Method:** {{{PlayMethod}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Artist:** {{{Artist}}}\n**- Track:** {{{Name}}}\n**- Album:** {{{Album}}} ({{Year}})\n**- Runtime:** {{RunTime}}"
             {{else}}
             {{#if_equals ItemType 'Episode'}}
                 "title": "{{{NotificationUsername}}} | Playback started: {{{SeriesName}}} ({{Year}}) - S{{SeasonNumber00}}E{{EpisodeNumber00}}",
-                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- Action:** Playback started\n**- Play Method:** {{{PlayMethod}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Series:** {{{SeriesName}}} ({{Year}})\n**- Episode:** S{{SeasonNumber00}}E{{EpisodeNumber00}} - {{{Name}}}\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
+                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Action:** Playback started\n**- Play Method:** {{{PlayMethod}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Series:** {{{SeriesName}}} ({{Year}})\n**- Episode:** S{{SeasonNumber00}}E{{EpisodeNumber00}} - {{{Name}}}\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
             {{else}}
                 "title": "{{{NotificationUsername}}} | Playback started: {{{Name}}} ({{Year}})",
-                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- Action:** Playback started\n**- Play Method:** {{{PlayMethod}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Movie:** {{{Name}}} ({{Year}})\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
+                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Action:** Playback started\n**- Play Method:** {{{PlayMethod}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Movie:** {{{Name}}} ({{Year}})\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
             {{/if_equals}}
             {{/if_equals}}
     {{/if_equals}}
@@ -37,14 +37,14 @@
         "actions": [{ "action": "view", "label": "Visit Jellyfin", "url": "{{{ServerUrl}}}web/#/details?id={{ItemId}}" }],
             {{#if_equals ItemType 'Audio'}}
                 "title": "{{{NotificationUsername}}} | Playback stopped: {{{Artist}}} - {{{Name}}} ({{Year}})",
-                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- Action:** Playback stopped\n**- Played To Completion:** {{{PlayedToCompletion}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Artist:** {{{Artist}}}\n**- Track:** {{{Name}}}\n**- Album:** {{{Album}}} ({{Year}})\n**- Runtime:** {{RunTime}}"
+                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Action:** Playback stopped\n**- Played To Completion:** {{{PlayedToCompletion}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Artist:** {{{Artist}}}\n**- Track:** {{{Name}}}\n**- Album:** {{{Album}}} ({{Year}})\n**- Runtime:** {{RunTime}}"
             {{else}}
             {{#if_equals ItemType 'Episode'}}
                 "title": "{{{NotificationUsername}}} | Playback stopped: {{{SeriesName}}} ({{Year}}) - S{{SeasonNumber00}}E{{EpisodeNumber00}}",
-                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- Action:** Playback stopped\n**- Played To Completion:** {{{PlayedToCompletion}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Series:** {{{SeriesName}}} ({{Year}})\n**- Episode:** S{{SeasonNumber00}}E{{EpisodeNumber00}} - {{{Name}}}\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
+                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Action:** Playback stopped\n**- Played To Completion:** {{{PlayedToCompletion}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Series:** {{{SeriesName}}} ({{Year}})\n**- Episode:** S{{SeasonNumber00}}E{{EpisodeNumber00}} - {{{Name}}}\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
             {{else}}
                 "title": "{{{NotificationUsername}}} | Playback stopped: {{{Name}}} ({{Year}})",
-                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- Action:** Playback stopped\n**- Played To Completion:** {{{PlayedToCompletion}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Movie:** {{{Name}}} ({{Year}})\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
+                "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Action:** Playback stopped\n**- Played To Completion:** {{{PlayedToCompletion}}}\n**- Playback Position:** {{{PlaybackPosition}}}\n\n**- Movie:** {{{Name}}} ({{Year}})\n**- Runtime:** {{RunTime}}\n\n**- Description:**\n{{Overview}}"
             {{/if_equals}}
             {{/if_equals}}
     {{/if_equals}}
@@ -93,18 +93,18 @@
     {{#if_equals NotificationType 'AuthenticationFailure'}}
         "title": "Alert: {{{Username}}}: Authentication Failure",
         "priority": 5,
-        "message": "---\n**- User:** {{{Username}}}\n**- Issue:** Login request was denied: Wrong password!"
+        "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Issue:** Login request was denied: Wrong password!"
     {{/if_equals}}
 
     {{#if_equals NotificationType 'AuthenticationSuccess'}}
         "title": "{{{NotificationUsername}}}: Authentication Success",
         "priority": 3,
-        "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Message:** Successfully logged in!"
+        "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Message:** Successfully logged in!"
     {{/if_equals}}
 
     {{#if_equals NotificationType 'UserLockedOut'}}
         "title": "Alert: {{{NotificationUsername}}}: User Locked Out",
         "priority": 5,
-        "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Issue:** User has been locked out!"
+        "message": "---\n**- User:** {{{NotificationUsername}}}\n**- Device/Client:** {{{DeviceName}}} - {{{ClientName}}}\n**- IP Address:** {{{RemoteEndPoint}}}\n**- Issue:** User has been locked out!"
     {{/if_equals}}
 }


### PR DESCRIPTION
This PR is an addition to my previous PRs #268 and #277

This PR adds `{{{RemoteEndPoint}}}` to these notifications thanks to PR #275 
- `PlaybackStart`
- `PlaybackStop`
- `AuthenticationFailure`

Furthermore, it adds `{{{DeviceName}}}` and `{{{ClientName}}}` to these notifications thanks to PR #284 
- `AuthenticationFailure`

- **Playback start/stop:**
![2024 10_ntfy sh_PlaybackStart_PlaybackStop](https://github.com/user-attachments/assets/2d29ba0c-d711-462e-848c-9b1f2901c338)

- **Authentication Failure:**
![2024 10_ntfy sh_AuthenticationFailure](https://github.com/user-attachments/assets/c3977780-2a65-47a0-8f84-89f2e9f17ed1)

I also wanted to add `{{{DeviceName}}}` `{{{ClientName}}}` `{{{RemoteEndPoint}}}` for these notifications:
- `AuthenticationSuccess`
- `UserLockedOut`

However, these appear to have only been partially implemented:

- **Authentication Success** (`{{{DeviceName}}}` seems to be implemented, `{{{ClientName}}}` and `{{{RemoteEndPoint}}}` are not implemented):
![2024 10_ntfy sh_AuthenticationSuccess](https://github.com/user-attachments/assets/09e34b4d-f78f-49ad-9913-ad2b8a8df7a1)

- **User Locked Out** (neither `{{{DeviceName}}}`, `{{{ClientName}}}` nor `{{{RemoteEndPoint}}}` are implemented):
![2024 10_ntfy sh_UserLockedOut](https://github.com/user-attachments/assets/deefc0ca-3c94-4b8b-8930-cf8e01bbe6d0)

Maybe @chiragkrishna can help me in this regard? I can also open an issue if preferred.