### PR TITLE
feat: add url_encode helper

### DIFF
--- a/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using HandlebarsDotNet;
+using System.Web; // Add this namespace for URL encoding
 
 namespace Jellyfin.Plugin.Webhook.Helpers;
 
@@ -46,6 +47,18 @@ public static class HandlebarsFunctionHelpers
         }
     };
 
+    private static readonly HandlebarsHelper UrlEncodeHelper = (writer, context, parameters) =>
+    {
+        if (parameters.Length != 1)
+        {
+            throw new HandlebarsException("{{url_encode}} helper must have exactly one argument");
+        }
+
+        var valueToEncode = GetStringValue(parameters[0]);
+        var encodedValue = HttpUtility.UrlEncode(valueToEncode);
+        writer.WriteSafeString(encodedValue);
+    };
+
     /// <summary>
     /// Register handlebars helpers.
     /// </summary>
@@ -57,6 +70,7 @@ public static class HandlebarsFunctionHelpers
         {
             writer.WriteSafeString($"<a href='{parameters["url"]}'>{context["text"]}</a>");
         });
+        Handlebars.RegisterHelper("url_encode", UrlEncodeHelper);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using HandlebarsDotNet;
-using System.Web; // Add this namespace for URL encoding
+using System.Web;
 
 namespace Jellyfin.Plugin.Webhook.Helpers;
 

--- a/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
-using HandlebarsDotNet;
 using System.Web;
+using HandlebarsDotNet;
 
 namespace Jellyfin.Plugin.Webhook.Helpers;
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ See [Templates](Jellyfin.Plugin.Webhook/Templates) for sample templates.
     - if the value of the parameter is not null or empty
 - link_to
     - wrap the $url and $text in an `<a>` tag
+- url_encode
+    - encode the given text to url-encoded format (useful for including text with spaces in urls)
 
 #### Variables:
 


### PR DESCRIPTION
I have a webhook which tries to put the series name into a url. Unfortunately discord does not handle urls with spaces at all. I thought `url_encode` would be helpful for others, and would also solve my problem with the least amount of changes.