### PR TITLE
Support for external ID's for Shows

### DIFF
--- a/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
@@ -106,6 +106,14 @@ public static class DataObjectHelpers
                     dataObject["SeasonNumber000"] = season.IndexNumber.Value.ToString("000", CultureInfo.InvariantCulture);
                 }
 
+                if (season.Series != null)
+                {
+                    foreach (var (providerKey, providerValue) in season.Series.ProviderIds)
+                    {
+                        dataObject[$"Provider_{providerKey.ToLowerInvariant()}_Show"] = providerValue;
+                    }
+                }
+
                 break;
             case Episode episode:
                 if (!string.IsNullOrEmpty(episode.Series?.Name))
@@ -157,6 +165,14 @@ public static class DataObjectHelpers
                 if (episode.Series?.AirTime is not null)
                 {
                     dataObject["AirTime"] = episode.Series.AirTime;
+                }
+
+                if (episode.Series != null)
+                {
+                    foreach (var (providerKey, providerValue) in episode.Series.ProviderIds)
+                    {
+                        dataObject[$"Provider_{providerKey.ToLowerInvariant()}_Show"] = providerValue;
+                    }
                 }
 
                 break;


### PR DESCRIPTION
Currently the webhook returns only the Episode external ID's.
This PR will also return the Show External ID's.

```
    "Provider_tvdb_Show": "76703",
    "Provider_imdb_Show": "tt0168366",
    "Provider_tmdb_Show": "60572",
    "Provider_tvmaze_Show": "590",
    "Provider_tvdb": "208324",
```