### PR TITLE
draft: Ignore items when the parent is in the queue

### DIFF
--- a/Jellyfin.Plugin.Webhook/Notifiers/ItemAddedNotifier/ItemAddedManager.cs
+++ b/Jellyfin.Plugin.Webhook/Notifiers/ItemAddedNotifier/ItemAddedManager.cs
@@ -54,11 +54,9 @@ public class ItemAddedManager : IItemAddedManager
         // Attempt to process all items in queue.
         var currentItems = _itemProcessQueue.ToArray();
 
-        var series = currentItems.
+        var itemsIds = currentItems.
             Select((item) => _libraryManager.GetItemById(item.Key)).
             Where((item) => item is not null).
-            Where((item) => item!.GetType() == typeof(Series)).
-            Select((item) => item as Series).
             Select((item) => item!.Id);
 
         if (currentItems.Length != 0)
@@ -78,7 +76,7 @@ public class ItemAddedManager : IItemAddedManager
                     }
 
                     // Remove the item if the parent is in the queue
-                    if (series.Contains(item.ParentId))
+                    if (itemsIds.Contains(item.ParentId))
                     {
                         _itemProcessQueue.TryRemove(key, out _);
                         continue;


### PR DESCRIPTION
Hi! Thank you for your work!

This PR is a fix regarding the "spam" encountered when adding an entire batch of Series. 
I tried to fix this by adding some timeout to avoid concurrency problems when adding items, 
And by actively ignoring new content when the parent's ID is present in the queue.

I'm marking this PR as a draft since I haven't gotten to testing just yet.