### PR TITLE
Construct SMTP addresses by parsing

### DIFF
--- a/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
@@ -35,8 +35,8 @@ public class SmtpClient : BaseClient, IWebhookClient<SmtpOption>
             }
 
             var message = new MimeMessage();
-            message.From.Add(new MailboxAddress(option.SenderAddress, option.SenderAddress));
-            message.To.Add(new MailboxAddress(option.ReceiverAddress, option.ReceiverAddress));
+            message.From.Add(MailboxAddress.Parse(option.SenderAddress));
+            message.To.Add(MailboxAddress.Parse(option.ReceiverAddress));
 
             message.Subject = option.GetCompiledSubjectTemplate()(data);
             var body = option.GetMessageBody(data);


### PR DESCRIPTION
By parsing the address strings users get to control sender names rather than being stuck with the email address itself being the sender name. This allows setting addresses like `Jellyfin <jellyfin@example.com>`.