### PR TITLE
add live tv as an option for notifications

### DIFF
--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
@@ -124,6 +124,10 @@
                 <span>Videos</span>
             </label>
             <label class="checkboxContainer">
+                <input is="emby-checkbox" type="checkbox" data-name="chkEnableLiveTV"/>
+                <span>Live TV</span>
+            </label>
+            <label class="checkboxContainer">
                 <input is="emby-checkbox" type="checkbox" data-name="chkSendAllProperties"/>
                 <span>Send All Properties (ignores template)</span>
             </label>

--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
@@ -160,6 +160,7 @@ export default function (view) {
                 element.querySelector("[data-name=chkEnableAlbums]").checked = config.EnableAlbums || (typeof config.EnableAlbums == "undefined");
                 element.querySelector("[data-name=chkEnableSongs]").checked = config.EnableSongs || (typeof config.EnableSongs == "undefined");
                 element.querySelector("[data-name=chkEnableVideos]").checked = config.EnableVideos || (typeof config.EnableVideos == "undefined");
+                element.querySelector("[data-name=chkEnableLiveTV]").checked = config.EnableLiveTV || (typeof config.EnableLiveTV == "undefined");
                 element.querySelector("[data-name=txtWebhookName]").value = config.WebhookName || "";
                 element.querySelector("[data-name=txtWebhookUri]").value = config.WebhookUri || "";
                 element.querySelector("[data-name=chkSendAllProperties]").checked = config.SendAllProperties || false;
@@ -184,6 +185,7 @@ export default function (view) {
                 config.EnableAlbums = element.querySelector("[data-name=chkEnableAlbums]").checked || false;
                 config.EnableSongs = element.querySelector("[data-name=chkEnableSongs]").checked || false;
                 config.EnableVideos = element.querySelector("[data-name=chkEnableVideos]").checked || false;
+                config.EnableLiveTV = element.querySelector("[data-name=chkEnableLiveTV]").checked || false;
                 config.WebhookName = element.querySelector("[data-name=txtWebhookName]").value || "";
                 config.WebhookUri = element.querySelector("[data-name=txtWebhookUri]").value || "";
                 config.SendAllProperties = element.querySelector("[data-name=chkSendAllProperties]").checked || false;

--- a/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/BaseOption.cs
@@ -68,6 +68,11 @@ public abstract class BaseOption
     public bool EnableVideos { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to notify on live TV.
+    /// </summary>
+    public bool EnableLiveTV { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to send all possible properties.
     /// </summary>
     public bool SendAllProperties { get; set; }

--- a/Jellyfin.Plugin.Webhook/WebhookSender.cs
+++ b/Jellyfin.Plugin.Webhook/WebhookSender.cs
@@ -17,6 +17,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.LiveTv;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Webhook;
@@ -172,6 +173,11 @@ public class WebhookSender : IWebhookSender
         }
 
         if (baseOptions.EnableVideos && itemType == typeof(Video))
+        {
+            return true;
+        }
+
+        if (baseOptions.EnableLiveTV && itemType == typeof(LiveTvChannel))
         {
             return true;
         }


### PR DESCRIPTION
Adds a check for content type `LiveTvChannel` to properly handle Live TV playback events. This change ensures that Live TV playback is correctly recognized and processed by the webhook plugin.

Fixes #158 