### PR TITLE
Add json_encode helper mostly for {{{Overview}}}

### DIFF
--- a/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Text.Json.JsonEncodedText;
 using System.Web;
 using HandlebarsDotNet;
 
@@ -59,6 +60,17 @@ public static class HandlebarsFunctionHelpers
         writer.WriteSafeString(encodedValue);
     };
 
+    private static readonly HandlebarsHelper JsonEncodeHelper = (writer, context, parameters) => {
+        if (parameters.Length != 1)
+        {
+            throw new HandlebarsException("{{json_encode}} helper must have exactly one argument");
+        }
+
+        var valueToEncode = GetStringValue(parameters[0]);
+        var encodedValue = JsonEncodedText.Encode(valueToEncode).ToString();
+        writer.WriteSafeString(encodedValue);
+    };
+
     /// <summary>
     /// Register handlebars helpers.
     /// </summary>
@@ -71,6 +83,7 @@ public static class HandlebarsFunctionHelpers
             writer.WriteSafeString($"<a href='{parameters["url"]}'>{context["text"]}</a>");
         });
         Handlebars.RegisterHelper("url_encode", UrlEncodeHelper);
+        Handlebars.RegisterHelper("json_encode", JsonEncodeHelper);
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ See [Templates](Jellyfin.Plugin.Webhook/Templates) for sample templates.
     - wrap the $url and $text in an `<a>` tag
 - url_encode
     - encode the given text to url-encoded format (useful for including text with spaces in urls)
+- json_encode
+    - encode the given text to JSON format (useful for strings that could contain newlines)
 
 #### Variables:
 


### PR DESCRIPTION
It seems that several people are having issues with the escaping of `Overview`. In addition to moving from `{{Overview}}` to `{{{Overview}}}` to avoid html escaping, the content may also contain characters that are not JSON-safe, such as unescaped newlines.

This PR adds a minimal helper in the style of `url_encode` that lets us `json_encode` instead.

I'd love to test this but my C# knowledge isn't very up to date. From looking at the GitHub workflows the build will probably at least create the dll asset for me?

Fixes https://github.com/jellyfin/jellyfin-plugin-webhook/issues/217