### PR TITLE
Webhook templates add more helpers

### DIFF
--- a/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
@@ -29,6 +29,34 @@ public static class HandlebarsFunctionHelpers
         }
     };
 
+    private static readonly HandlebarsBlockHelper StringEqualityAllHelper = (output, options, context, arguments) =>
+    {
+        if (arguments.Length < 2)
+        {
+            throw new HandlebarsException("{{if_all}} helper must have at least two arguments");
+        }
+
+        var argument = GetStringValue(arguments[0]);
+        bool isMatch = true;
+        for (int i = 1; i < arguments.Length; i++)
+        {
+            if (!string.Equals(argument, GetStringValue(arguments[i]), StringComparison.OrdinalIgnoreCase))
+            {
+                isMatch = false;
+                break;
+            }
+        }
+
+        if (isMatch)
+        {
+            options.Template(output, context);
+        }
+        else
+        {
+            options.Inverse(output, context);
+        }
+    };
+
     private static readonly HandlebarsBlockHelper StringEqualityAnyHelper = (output, options, context, arguments) =>
     {
         if (arguments.Length < 2)
@@ -92,6 +120,7 @@ public static class HandlebarsFunctionHelpers
     /// </summary>
     public static void RegisterHelpers()
     {
+        Handlebars.RegisterHelper("if_all", StringEqualityAllHelper);
         Handlebars.RegisterHelper("if_any", StringEqualityAnyHelper);
         Handlebars.RegisterHelper("if_equals", StringEqualityHelper);
         Handlebars.RegisterHelper("if_exist", StringExistHelper);

--- a/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/HandlebarsFunctionHelpers.cs
@@ -29,6 +29,34 @@ public static class HandlebarsFunctionHelpers
         }
     };
 
+    private static readonly HandlebarsBlockHelper StringEqualityAnyHelper = (output, options, context, arguments) =>
+    {
+        if (arguments.Length < 2)
+        {
+            throw new HandlebarsException("{{if_any}} helper must have at least two arguments");
+        }
+
+        var argument = GetStringValue(arguments[0]);
+        bool isMatch = false;
+        for (int i = 1; i < arguments.Length; i++)
+        {
+            if (string.Equals(argument, GetStringValue(arguments[i]), StringComparison.OrdinalIgnoreCase))
+            {
+                isMatch = true;
+                break;
+            }
+        }
+
+        if (isMatch)
+        {
+            options.Template(output, context);
+        }
+        else
+        {
+            options.Inverse(output, context);
+        }
+    };
+
     private static readonly HandlebarsBlockHelper StringExistHelper = (output, options, context, arguments) =>
     {
         if (arguments.Length != 1)
@@ -64,6 +92,7 @@ public static class HandlebarsFunctionHelpers
     /// </summary>
     public static void RegisterHelpers()
     {
+        Handlebars.RegisterHelper("if_any", StringEqualityAnyHelper);
         Handlebars.RegisterHelper("if_equals", StringEqualityHelper);
         Handlebars.RegisterHelper("if_exist", StringExistHelper);
         Handlebars.RegisterHelper("link_to", (writer, context, parameters) =>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ See [Templates](Jellyfin.Plugin.Webhook/Templates) for sample templates.
 
 #### Helpers:
 
+- if_any
+    - if first parameter equals _any_ of the following parameters case insensitive (logical OR)
+- if_all
+    - if first parameter equals _all_ of the following parameters case insensitive (logical AND)
 - if_equals
     - if first parameter equals second parameter case insensitive
 - if_exist


### PR DESCRIPTION
Adds `if_any` and `if_all` helpers to allow comparing a variable to multiple values.\
May replace `if_equal`, but to avoid breaking backwards-compatibility I've left it as-is.

I'm used to C# solutions having unit-testing projects, but could find none so no tests were added.

Closes #343.