### PR TITLE
feat: add Webhook plugin pages to Jellyfin Dashboard menu

### DIFF
--- a/Jellyfin.Plugin.Webhook/WebhookPlugin.cs
+++ b/Jellyfin.Plugin.Webhook/WebhookPlugin.cs
@@ -47,6 +47,7 @@ public class WebhookPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         yield return new PluginPageInfo
         {
             Name = Name,
+            EnableInMainMenu = true,
             EmbeddedResourcePath = prefix + ".Configuration.Web.config.html"
         };
 


### PR DESCRIPTION
set optional `PluginPageInfo` `EnableInMainMenu` flag to true to list the plugin page in Dashboard Plugins menu section.

This allows users to open the configuration page for the plugin directly from the Plugins section in the sidebar, instead of navigating through Dashboard -> Plugins -> Webhook (selected from all installed plugins) -> Settings.

<details>
<summary>Before / After</summary>

https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=4c5ae2ce-f5fb-11f0-ba1b-0e6f42328d7d

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/d9c6e432-ee98-4a36-927f-ff384541be57" width="400" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/5986a727-dfb2-4cd9-bc40-98fb5282c815" width="400" />
    </td>
  </tr>
</table>

</details>



