### PR TITLE
Add variable for Guid without dashes

### DIFF
--- a/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
+++ b/Jellyfin.Plugin.Webhook/Helpers/DataObjectHelpers.cs
@@ -296,6 +296,7 @@ public static class DataObjectHelpers
     {
         dataObject["NotificationUsername"] = user.Name.Escape();
         dataObject["UserId"] = user.Id;
+        dataObject["UserIdN"] = user.Id.ToString("N");
         dataObject[nameof(user.LastLoginDate)] = user.LastLoginDate ?? DateTime.UtcNow;
         dataObject[nameof(user.LastActivityDate)] = user.LastActivityDate ?? DateTime.MinValue;
 
@@ -312,6 +313,7 @@ public static class DataObjectHelpers
     {
         dataObject["NotificationUsername"] = user.Username.Escape();
         dataObject["UserId"] = user.Id;
+        dataObject["UserIdN"] = user.Id.ToString("N");
         dataObject[nameof(user.LastLoginDate)] = user.LastLoginDate ?? DateTime.UtcNow;
         dataObject[nameof(user.LastActivityDate)] = user.LastActivityDate ?? DateTime.MinValue;
 
@@ -332,6 +334,7 @@ public static class DataObjectHelpers
         }
 
         dataObject[nameof(sessionInfo.UserId)] = sessionInfo.UserId;
+        dataObject["UserIdN"] = sessionInfo.UserId.ToString("N");
         dataObject["NotificationUsername"] = sessionInfo.UserName.Escape();
         dataObject[nameof(sessionInfo.Client)] = sessionInfo.Client.Escape();
         dataObject[nameof(sessionInfo.LastActivityDate)] = sessionInfo.LastActivityDate;
@@ -365,6 +368,7 @@ public static class DataObjectHelpers
         }
 
         dataObject[nameof(sessionInfo.UserId)] = sessionInfo.UserId;
+        dataObject["UserIdN"] = sessionInfo.UserId.ToString("N");
         dataObject["NotificationUsername"] = sessionInfo.UserName.Escape();
         dataObject[nameof(sessionInfo.Client)] = sessionInfo.Client.Escape();
         dataObject[nameof(sessionInfo.LastActivityDate)] = sessionInfo.LastActivityDate;

--- a/Jellyfin.Plugin.Webhook/Notifiers/AuthenticationFailureNotifier.cs
+++ b/Jellyfin.Plugin.Webhook/Notifiers/AuthenticationFailureNotifier.cs
@@ -42,7 +42,7 @@ public class AuthenticationFailureNotifier : IEventConsumer<AuthenticationReques
         dataObject[nameof(eventArgs.App)] = eventArgs.App ?? string.Empty;
         dataObject[nameof(eventArgs.Username)] = eventArgs.Username ?? string.Empty;
         dataObject[nameof(eventArgs.UserId)] = eventArgs.UserId ?? Guid.Empty;
-        dataObject["UserIdN"] = eventArgs.UserId.ToString("N") ?? string.Empty;
+        dataObject["UserIdN"] = eventArgs.UserId?.ToString("N") ?? string.Empty;
         dataObject[nameof(eventArgs.AppVersion)] = eventArgs.AppVersion ?? string.Empty;
         dataObject[nameof(eventArgs.DeviceId)] = eventArgs.DeviceId ?? string.Empty;
         dataObject[nameof(eventArgs.DeviceName)] = eventArgs.DeviceName ?? string.Empty;

--- a/Jellyfin.Plugin.Webhook/Notifiers/AuthenticationFailureNotifier.cs
+++ b/Jellyfin.Plugin.Webhook/Notifiers/AuthenticationFailureNotifier.cs
@@ -42,6 +42,7 @@ public class AuthenticationFailureNotifier : IEventConsumer<AuthenticationReques
         dataObject[nameof(eventArgs.App)] = eventArgs.App ?? string.Empty;
         dataObject[nameof(eventArgs.Username)] = eventArgs.Username ?? string.Empty;
         dataObject[nameof(eventArgs.UserId)] = eventArgs.UserId ?? Guid.Empty;
+        dataObject["UserIdN"] = eventArgs.UserId.ToString("N") ?? string.Empty;
         dataObject[nameof(eventArgs.AppVersion)] = eventArgs.AppVersion ?? string.Empty;
         dataObject[nameof(eventArgs.DeviceId)] = eventArgs.DeviceId ?? string.Empty;
         dataObject[nameof(eventArgs.DeviceName)] = eventArgs.DeviceName ?? string.Empty;

--- a/Jellyfin.Plugin.Webhook/Notifiers/PlaybackProgressNotifier.cs
+++ b/Jellyfin.Plugin.Webhook/Notifiers/PlaybackProgressNotifier.cs
@@ -64,7 +64,8 @@ public class PlaybackProgressNotifier : IEventConsumer<PlaybackProgressEventArgs
             var userDataObject = new Dictionary<string, object>(dataObject)
             {
                 ["NotificationUsername"] = user.Username,
-                ["UserId"] = user.Id
+                ["UserId"] = user.Id,
+                ["UserIdN"] = user.Id.ToString("N")
             };
 
             await _webhookSender.SendNotification(NotificationType.PlaybackProgress, userDataObject, eventArgs.Item.GetType())

--- a/Jellyfin.Plugin.Webhook/Notifiers/PlaybackStartNotifier.cs
+++ b/Jellyfin.Plugin.Webhook/Notifiers/PlaybackStartNotifier.cs
@@ -64,7 +64,8 @@ public class PlaybackStartNotifier : IEventConsumer<PlaybackStartEventArgs>
             var userDataObject = new Dictionary<string, object>(dataObject)
             {
                 ["NotificationUsername"] = user.Username,
-                ["UserId"] = user.Id
+                ["UserId"] = user.Id,
+                ["UserIdN"] = user.Id.ToString("N")
             };
 
             await _webhookSender.SendNotification(NotificationType.PlaybackStart, userDataObject, eventArgs.Item.GetType())

--- a/Jellyfin.Plugin.Webhook/Notifiers/PlaybackStopNotifier.cs
+++ b/Jellyfin.Plugin.Webhook/Notifiers/PlaybackStopNotifier.cs
@@ -65,7 +65,8 @@ public class PlaybackStopNotifier : IEventConsumer<PlaybackStopEventArgs>
             var userDataObject = new Dictionary<string, object>(dataObject)
             {
                 ["NotificationUsername"] = user.Username,
-                ["UserId"] = user.Id
+                ["UserId"] = user.Id,
+                ["UserIdN"] = user.Id.ToString("N")
             };
 
             await _webhookSender.SendNotification(NotificationType.PlaybackStop, userDataObject, eventArgs.Item.GetType())

--- a/Jellyfin.Plugin.Webhook/Notifiers/UserDataSavedNotifier/UserDataSavedNotifierEntryPoint.cs
+++ b/Jellyfin.Plugin.Webhook/Notifiers/UserDataSavedNotifier/UserDataSavedNotifierEntryPoint.cs
@@ -69,6 +69,7 @@ public class UserDataSavedNotifierEntryPoint : IHostedService
             dataObject["SaveReason"] = eventArgs.SaveReason.ToString();
             dataObject["NotificationUsername"] = user.Username;
             dataObject["UserId"] = user.Id;
+            dataObject["UserIdN"] = user.Id.ToString("N");
 
             var scope = _applicationHost.ServiceProvider!.CreateAsyncScope();
             await using (scope.ConfigureAwait(false))

--- a/Jellyfin.Plugin.Webhook/Templates/Discord/UserLockedOut.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Discord/UserLockedOut.handlebars
@@ -7,11 +7,11 @@
             "author": {
                 "name": "User Locked Out • {{{NotificationUsername}}}",
 
-                "url": "{{ServerUrl}}/web/index.html#!/useredit.html?userId={{UserId}}"
+                "url": "{{ServerUrl}}/web/index.html#/dashboard/users/profile?userId={{UserIdN}}"
             },
 
             "thumbnail":{
-                "url": "{{ServerUrl}}/Users/{{UserId}}/Images/Primary"
+                "url": "{{ServerUrl}}/Users/{{UserIdN}}/Images/Primary"
             },
 
             "description": "
@@ -20,11 +20,11 @@
             {{~/if_exist~}}
             
             {{~#if_exist ServerUrl~}}
-                [**Enable User **]({{ServerUrl}}/web/index.html#!/useredit.html?userId={{UserId}})
+                [**Enable User **]({{ServerUrl}}/web/index.html#/dashboard/users/profile?userId={{UserIdN}})
             {{~/if_exist~}}
 
             {{~#if_exist ServerUrl~}}
-                • [**Reset Password**]({{ServerUrl}}/web/index.html#!/userpassword.html?userId={{UserId}})
+                • [**Reset Password**]({{ServerUrl}}/web/index.html#/dashboard/users/password?userId={{UserIdN}})
             {{~/if_exist~}}
             ",
 

--- a/Jellyfin.Plugin.Webhook/Templates/GenericNotification.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/GenericNotification.handlebars
@@ -5,5 +5,6 @@
     "Level": "{{Level}}",
     "Url": "{{Url}}",
     "Username": "{{{Username}}}",
-    "UserId": "{{UserId}}"
+    "UserId": "{{UserId}}",
+    "UserIdN": "{{UserIdN}}"
 }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ See [Templates](Jellyfin.Plugin.Webhook/Templates) for sample templates.
         - Current user name
     - UserId
         - User ID
+    - UserIdN
+        - User ID, hyphens removed
     - LastLoginDate
         - Last user login date
     - LastActivityDate


### PR DESCRIPTION
Jellyfin still uses Guids without dashes by default (["N" type Guid format](https://learn.microsoft.com/en-us/dotnet/api/system.guid.tostring?view=net-9.0#system-guid-tostring(system-string))), as do some services that integrate with Jellyfin. This would add an additional variable that exposes this same format for Webhooks.

This is as opposed to the current `UserId` variable which contains dashes ("D" type Guid format).

Alternative approach is making more Handlebars helpers available, such as a "replace" helper.