### PR TITLE
fix: trim whitespace from SMTP server address before connecting

### DIFF
--- a/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
+++ b/Jellyfin.Plugin.Webhook/Destinations/Smtp/SmtpClient.cs
@@ -49,7 +49,7 @@ public class SmtpClient : BaseClient, IWebhookClient<SmtpOption>
 
             using var smtpClient = new MailKit.Net.Smtp.SmtpClient();
             var secureSocketOptions = option.UseSsl ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.None;
-            await smtpClient.ConnectAsync(option.SmtpServer, option.SmtpPort, secureSocketOptions)
+            await smtpClient.ConnectAsync(option.SmtpServer.Trim(), option.SmtpPort, secureSocketOptions)
                 .ConfigureAwait(false);
             if (option.UseCredentials)
             {


### PR DESCRIPTION
When a user pastes an SMTP server hostname that has a trailing or leading space (easy to do when copying from a browser), ConnectAsync fails with a DNS error. This one-line fix calls .Trim() on the server address before the connection is made.