### PR TITLE
Adds a test button

### DIFF
--- a/Jellyfin.Plugin.Webhook/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Webhook/Configuration/PluginConfiguration.cs
@@ -8,6 +8,7 @@ using Jellyfin.Plugin.Webhook.Destinations.Pushbullet;
 using Jellyfin.Plugin.Webhook.Destinations.Pushover;
 using Jellyfin.Plugin.Webhook.Destinations.Slack;
 using Jellyfin.Plugin.Webhook.Destinations.Smtp;
+using Jellyfin.Plugin.Webhook.Tester;
 using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.Webhook.Configuration;
@@ -32,6 +33,7 @@ public class PluginConfiguration : BasePluginConfiguration
         SlackOptions = Array.Empty<SlackOption>();
         SmtpOptions = Array.Empty<SmtpOption>();
         MqttOptions = Array.Empty<MqttOption>();
+        TestOptions = Array.Empty<TestOption>();
     }
 
     /// <summary>
@@ -83,4 +85,9 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the mqtt options.
     /// </summary>
     public MqttOption[] MqttOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the test options.
+    /// </summary>
+    public TestOption[] TestOptions { get; set; }
 }

--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
@@ -50,6 +50,12 @@
             <button id="saveConfig" is="emby-button" type="submit" class="raised button-submit block">
                 <span>Save</span>
             </button>
+            <button id="btnAddTest" is="emby-button" type="button" class="raised button block">
+                <span>Add Test</span>
+            </button>
+            <br />
+            <div id="testWrapper"></div>
+            <br />
         </form>
     </div>
 
@@ -59,7 +65,7 @@
             <span data-name="notificationTypeName"></span>
         </label>
     </template>
-    
+
     <template id="template-user-filter">
         <label class="checkboxContainer">
             <input is="emby-checkbox" type="checkbox" data-name="userFilterValue"/>
@@ -269,80 +275,80 @@
             <input is="emby-input" type="text" data-name="txtValue" label="Value:"/>
         </div>
     </template>
-    
-<template id="template-smtp">
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtSenderAddress" label="Sender Address:"/>
-    </div>
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtReceiverAddress" label="Receiver Address:"/>
-    </div>
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtSmtpServer" label="SMTP Server Address:"/>
-    </div>
-    <div class="inputContainer">
-        <input is="emby-input" type="number" data-name="txtSmtpPort" label="SMTP Port:"/>
-    </div>
-    <label class="checkboxContainer">
-        <input is="emby-checkbox" type="checkbox" data-name="chkUseCredentials"/>
-        <span>Use Credentials</span>
-    </label>
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtUsername" label="Username:"/>
-    </div>
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtPassword" label="Password:"/>
-    </div>
-    <label class="checkboxContainer">
-        <input is="emby-checkbox" type="checkbox" data-name="chkUseSsl"/>
-        <span>Use SSL</span>
-    </label>
-    <label class="checkboxContainer">
-        <input is="emby-checkbox" type="checkbox" data-name="chkIsHtml"/>
-        <span>Is Html Body</span>
-    </label>
-    <div class="inputContainer">
-        <label>Subject Template:</label>
-        <div>
-            <textarea data-name="txtSubjectTemplate" style="width: 100%; height: 400px"></textarea>
+
+    <template id="template-smtp">
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtSenderAddress" label="Sender Address:"/>
         </div>
-    </div>        
-</template>
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtReceiverAddress" label="Receiver Address:"/>
+        </div>
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtSmtpServer" label="SMTP Server Address:"/>
+        </div>
+        <div class="inputContainer">
+            <input is="emby-input" type="number" data-name="txtSmtpPort" label="SMTP Port:"/>
+        </div>
+        <label class="checkboxContainer">
+            <input is="emby-checkbox" type="checkbox" data-name="chkUseCredentials"/>
+            <span>Use Credentials</span>
+        </label>
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtUsername" label="Username:"/>
+        </div>
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtPassword" label="Password:"/>
+        </div>
+        <label class="checkboxContainer">
+            <input is="emby-checkbox" type="checkbox" data-name="chkUseSsl"/>
+            <span>Use SSL</span>
+        </label>
+        <label class="checkboxContainer">
+            <input is="emby-checkbox" type="checkbox" data-name="chkIsHtml"/>
+            <span>Is Html Body</span>
+        </label>
+        <div class="inputContainer">
+            <label>Subject Template:</label>
+            <div>
+                <textarea data-name="txtSubjectTemplate" style="width: 100%; height: 400px"></textarea>
+            </div>
+        </div>
+    </template>
 
-<template id="template-mqtt">
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtMqttServer" label="MQTT Server:" />
-    </div>
-    <div class="inputContainer">
-        <input is="emby-input" type="number" data-name="txtMqttPort" label="MQTT Port (default is 1883):" />
-    </div>
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtTopic" label="Topic:" />
-    </div>
-    <label class="checkboxContainer">
-        <input is="emby-checkbox" type="checkbox" data-name="chkUseCredentials" />
-        <span>Use Credentials</span>
-    </label>
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtUsername" label="Username:" />
-    </div>
-    <div class="inputContainer">
-        <input is="emby-input" type="text" data-name="txtPassword" label="Password:" />
-    </div>
-    <label class="checkboxContainer">
-        <input is="emby-checkbox" type="checkbox" data-name="chkUseTls" />
-        <span>Use TLS</span>
-    </label>
-    <div class="selectContainer">
-        <select is="emby-select" data-name="ddlQosLevel" label="Quality of Service:">
-            <option value="AtMostOnce">At Most Once</option>
-            <option value="AtLeastOnce">At Least Once</option>
-            <option value="ExactlyOnce">Exactly Once</option>
-        </select>
-    </div>
-</template>
+    <template id="template-mqtt">
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtMqttServer" label="MQTT Server:" />
+        </div>
+        <div class="inputContainer">
+            <input is="emby-input" type="number" data-name="txtMqttPort" label="MQTT Port (default is 1883):" />
+        </div>
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtTopic" label="Topic:" />
+        </div>
+        <label class="checkboxContainer">
+            <input is="emby-checkbox" type="checkbox" data-name="chkUseCredentials" />
+            <span>Use Credentials</span>
+        </label>
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtUsername" label="Username:" />
+        </div>
+        <div class="inputContainer">
+            <input is="emby-input" type="text" data-name="txtPassword" label="Password:" />
+        </div>
+        <label class="checkboxContainer">
+            <input is="emby-checkbox" type="checkbox" data-name="chkUseTls" />
+            <span>Use TLS</span>
+        </label>
+        <div class="selectContainer">
+            <select is="emby-select" data-name="ddlQosLevel" label="Quality of Service:">
+                <option value="AtMostOnce">At Most Once</option>
+                <option value="AtLeastOnce">At Least Once</option>
+                <option value="ExactlyOnce">Exactly Once</option>
+            </select>
+        </div>
+    </template>
 
-<template id="template-pushbullet">
+    <template id="template-pushbullet">
         <div class="inputContainer">
             <input is="emby-input" type="text" data-name="txtToken" label="Token:"/>
         </div>
@@ -362,7 +368,36 @@
             <input is="emby-input" type="text" data-name="txtIconUrl" label="Icon Url:"/>
         </div>
     </template>
-    
+
+    <template id="template-test">
+        <div class="selectContainer">
+            <select is="emby-select" data-name="notificationTypeSelector" label="Notification Type:">
+                <option value="None">None</option>
+            </select>
+        </div>
+        <div class="selectContainer">
+            <select is="emby-select" data-name="itemTypeSelector" label="Item Type:">
+                <option value="None">None</option>
+                <option value="Movie">Movie</option>
+                <option value="Episode">Episode</option>
+                <option value="Season">Season</option>
+                <option value="Series">Series</option>
+                <option value="Album">Album</option>
+                <option value="Song">Song</option>
+                <option value="Video">Video</option>
+            </select>
+        </div>
+        <div class="inputContainer">
+            <label>Test Data JSON:</label>
+            <div>
+                <textarea data-name="txtTestData" style="width: 100%; height: 400px"></textarea>
+            </div>
+        </div>
+        <button id="btnTest" is="emby-button" type="submit" class="raised button-submit block">
+            <span>Save and Test</span>
+        </button>
+    </template>
+
     <style>
         .checkboxContainer {
             max-width: fit-content;

--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
@@ -31,13 +31,87 @@ export default function (view) {
         return cur;
     }
 
+    const defaultTestData =
+`{
+  "NotificationUsername": "",
+  "Username": "",
+  "UserId": "00000000-0000-0000-0000-000000000000",
+  "LastLoginDate": "1970-01-01T00:00:00Z",
+  "LastActivityDate": "1970-01-01T00:00:00Z",
+  
+  "DeviceName": "",
+  "DeviceId": "",
+  
+  "ClientName": "",
+  "Client": "",
+  "RemoteEndPoint": "",
+  
+  "Timestamp": "1970-01-01T00:00:00Z",
+  "UtcTimestamp": "1970-01-01T00:00:00Z",
+  "Name": "",
+  "Overview": "",
+  "Tagline": "",
+  "ItemId": "00000000-0000-0000-0000-000000000000",
+  "RunTimeTicks": 0,
+  "RunTime": "",
+  "Year": 0,
+  "PremiereDate": "1970-01-01T00:00:00Z",
+  "Genres": [],
+  "AspectRatio": "",
+  "MediaSourceId": "",
+  "Provider_tmdb": "",
+  "Provider_imdb": "",
+  
+  "SeriesName": "",
+  "SeriesId": "00000000-0000-0000-0000-000000000000",
+  "SeriesPremiereDate": "1970-01-01T00:00:00Z",
+  "SeasonNumber": 0,
+  "SeasonNumber00": "",
+  "SeasonNumber000": "",
+  
+  "EpisodeNumber": 0,
+  "EpisodeNumber00": "",
+  "EpisodeNumber000": "",
+  "EpisodeNumberEnd": 0,
+  "EpisodeNumberEnd00": "",
+  "EpisodeNumberEnd000": "",
+  "AirTime": "",
+  
+  "Album": "",
+  "Artist": "",
+  
+  "PlaybackPositionTicks": 0,
+  "PlaybackPosition": "",
+  "PlayMethod": "",
+  "PlayedToCompletion": "",
+  "IsPaused": false,
+  "IsAutomated": false,
+  "Likes": false,
+  "Rating": 0,
+  "PlayCount": 0,
+  "Favorite": false,
+  "Played": false,
+  "AudioStreamIndex": 0,
+  "SubtitleStreamIndex": 0,
+  "LastPlayedDate": "1970-01-01T00:00:00Z",
+  
+  "PluginId": "00000000-0000-0000-0000-000000000000",
+  "PluginName": "",
+  "PluginVersion": "",
+  "PluginChangelog": "",
+  "PluginChecksum": "",
+  "PluginSourceUrl": ""
+}
+`
+
     const Webhook = {
         pluginId: "71552A5A-5C5C-4350-A2AE-EBE451A30173",
 
         configurationWrapper: document.querySelector("#configurationWrapper"),
+        testWrapper: document.querySelector("#testWrapper"),
 
         notificationType: {
-            template: document.querySelector("#template-notification-type"),
+            checkboxTemplate: document.querySelector("#template-notification-type"),
             values: {
                 "ItemAdded": "Item Added",
                 "ItemDeleted": "Item Deleted",
@@ -63,10 +137,10 @@ export default function (view) {
                 "UserUpdated": "User Updated",
                 "UserDataSaved": "User Data Saved"
             },
-            create: function (container, selected = []) {
+            createCheckboxes: function (container, selected = []) {
                 const notificationTypeKeys = Object.keys(Webhook.notificationType.values).sort();
                 for (const key of notificationTypeKeys) {
-                    const template = Webhook.notificationType.template.cloneNode(true).content;
+                    const template = Webhook.notificationType.checkboxTemplate.cloneNode(true).content;
                     const name = template.querySelector("[data-name=notificationTypeName]");
                     const value = template.querySelector("[data-name=notificationTypeValue]");
 
@@ -77,13 +151,24 @@ export default function (view) {
                     container.appendChild(template);
                 }
             },
-            get: function (container) {
+            getCheckboxes: function (container) {
                 const notificationTypes = [];
                 const checkboxes = container.querySelectorAll('[data-name=notificationTypeValue]:checked');
                 for (const checkbox of checkboxes) {
                     notificationTypes.push(checkbox.dataset.value);
                 }
                 return notificationTypes;
+            },
+            createOptions: function (container, selected = null) {
+                const notificationTypeKeys = Object.keys(Webhook.notificationType.values).sort();
+                for (const key of notificationTypeKeys) {
+                    const option = document.createElement("option");
+                    option.value = key
+                    option.innerText = Webhook.notificationType.values[key];
+
+                    container.appendChild(option);
+                }
+                container.value = selected
             }
         },
         userFilter: {
@@ -169,7 +254,7 @@ export default function (view) {
                 element.querySelector("[data-name=txtTemplate]").value = Webhook.atou(config.Template || "");
 
                 const notificationTypeContainer = element.querySelector("[data-name=notificationTypeContainer]");
-                Webhook.notificationType.create(notificationTypeContainer, config.NotificationTypes);
+                Webhook.notificationType.createCheckboxes(notificationTypeContainer, config.NotificationTypes);
 
                 const userFilterContainer = element.querySelector("[data-name=userFilterContainer]");
                 Webhook.userFilter.create(userFilterContainer, config.UserFilter);
@@ -193,7 +278,7 @@ export default function (view) {
                 config.Template = Webhook.utoa(element.querySelector("[data-name=txtTemplate]").value || "");
 
                 config.NotificationTypes = [];
-                config.NotificationTypes = Webhook.notificationType.get(element);
+                config.NotificationTypes = Webhook.notificationType.getCheckboxes(element);
 
                 config.UserFilter = [];
                 config.UserFilter = Webhook.userFilter.get(element);
@@ -620,9 +705,110 @@ export default function (view) {
                 return config;
             }
         },
+        tester: {
+            btnAdd: document.querySelector("#btnAddTest"),
+            template: document.querySelector("#template-test"),
+            addConfig: function (config) {
+                const collapse = document.createElement("div");
+                collapse.setAttribute("is", "emby-collapse");
+                collapse.dataset.testWrapper = "2";
+
+                const collapseContent = document.createElement("div");
+                collapseContent.classList.add("collapseContent");
+
+                // Append template content.
+                const template = document.createElement("div");
+                template.dataset.type = "tester";
+                template.appendChild(Webhook.tester.template.cloneNode(true).content);
+                template.querySelector("#btnTest").addEventListener("click", Webhook.tester.test);
+                collapseContent.appendChild(template);
+
+                // Append removal button.
+                const btnRemove = document.createElement("button");
+                btnRemove.innerText = "Remove";
+                btnRemove.setAttribute("is", "emby-button");
+                btnRemove.classList.add("raised", "button-warning", "block");
+                btnRemove.addEventListener("click", Webhook.tester.removeConfig);
+                collapseContent.appendChild(btnRemove);
+
+                collapse.appendChild(collapseContent);
+
+                Webhook.testWrapper.appendChild(collapse);
+
+                // Load configuration
+                Webhook.tester.setConfig(config, collapse);
+            },
+            removeConfig: function (e) {
+                e.preventDefault();
+                findParentBySelector(e.target, '[data-test-wrapper]').remove();
+            },
+            setConfig: function (config, element) {
+                const notificationTypeSelector = element.querySelector("[data-name=notificationTypeSelector]");
+                Webhook.notificationType.createOptions(notificationTypeSelector, config.NotificationType);
+                notificationTypeSelector.value = config.NotificationType || "None";
+                element.querySelector("[data-name=itemTypeSelector]").value = config.ItemType || "None";
+                element.querySelector("[data-name=txtTestData]").value = config.TestData ? Webhook.atou(config.TestData) : defaultTestData;
+            },
+            getConfig: function (element) {
+                const config = {}
+                config.NotificationType = element.querySelector("[data-name=notificationTypeSelector]").value || "None";
+                config.ItemType = element.querySelector("[data-name=itemTypeSelector]").value || "None";
+                config.TestData = Webhook.utoa(element.querySelector("[data-name=txtTestData]").value || defaultTestData);
+                return config;
+            },
+            test: async function (element) {
+                element.preventDefault();
+
+                Dashboard.showLoadingMsg();
+
+                // Save configuration before testing to ensure test uses latest configuration values.
+                const config = Webhook.getConfig();
+                await window.ApiClient.updatePluginConfiguration(Webhook.pluginId, config);
+
+                // Get test data.
+                parent = findParentBySelector(element.target, '[data-test-wrapper]');
+                const notificationType = parent.querySelector("[data-name=notificationTypeSelector]").value || "";
+                const itemType = parent.querySelector("[data-name=itemTypeSelector]").value || "None";
+                const testData = Webhook.utoa(parent.querySelector("[data-name=txtTestData]").value || "");
+
+                // Make API call to test the webhooks.
+                const testWebhookUrl = window.ApiClient.serverAddress() + "/Webhook/Test";
+                const data = {
+                    notificationType,
+                    itemType,
+                    testData
+                }
+                try {
+                    const response = await fetch(testWebhookUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization':
+                                'MediaBrowser Client=' + window.ApiClient.appName() +
+                                ', Device=' + window.ApiClient.deviceName() +
+                                ', DeviceId=' + window.ApiClient.deviceId() +
+                                ', Version=' + window.ApiClient.appVersion() +
+                                ', Token=' + window.ApiClient.accessToken()
+                        },
+                        body: JSON.stringify(data)
+                    })
+
+                    if (!response.ok) {
+                        throw new Error(`Status ${response.status} ${response.statusText}`);
+                    }
+
+                    Dashboard.alert("Test notification sent.");
+                } catch (error) {
+                    Dashboard.alert(`Test notification send failed: ${error.message}`);
+                }
+
+                Dashboard.hideLoadingMsg()
+            }
+        },
         init: async function () {
             // Clear any previously loaded configuration.
             Webhook.configurationWrapper.innerHTML = "";
+            Webhook.testWrapper.innerHTML = "";
 
             // Add click handlers
             Webhook.discord.btnAdd.addEventListener("click", Webhook.discord.addConfig);
@@ -634,6 +820,7 @@ export default function (view) {
             Webhook.slack.btnAdd.addEventListener("click", Webhook.slack.addConfig);
             Webhook.smtp.btnAdd.addEventListener("click", Webhook.smtp.addConfig);
             Webhook.mqtt.btnAdd.addEventListener("click", Webhook.mqtt.addConfig);
+            Webhook.tester.btnAdd.addEventListener("click", Webhook.tester.addConfig);
             document.querySelector("#saveConfig").addEventListener("click", Webhook.saveConfig);
 
             await Webhook.userFilter.populate();
@@ -643,11 +830,7 @@ export default function (view) {
             e.preventDefault();
             findParentBySelector(e.target, '[data-config-wrapper]').remove();
         },
-        saveConfig: function (e) {
-            e.preventDefault();
-
-            Dashboard.showLoadingMsg();
-
+        getConfig: function (e) {
             const config = {};
             config.ServerUrl = document.querySelector("#txtServerUrl").value;
             config.DiscordOptions = [];
@@ -704,6 +887,21 @@ export default function (view) {
                 config.MqttOptions.push(Webhook.mqtt.getConfig(mqttConfigs[i]));
             }
 
+            config.TestOptions = [];
+            const testOptions = document.querySelectorAll("[data-type=tester]");
+            for (let i = 0; i < testOptions.length; i++) {
+                config.TestOptions.push(Webhook.tester.getConfig(testOptions[i]));
+            }
+
+            return config;
+        },
+        saveConfig: function (e) {
+            e.preventDefault();
+
+            Dashboard.showLoadingMsg();
+
+            const config = Webhook.getConfig()
+
             window.ApiClient.updatePluginConfiguration(Webhook.pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
         },
         loadConfig: function () {
@@ -745,6 +943,10 @@ export default function (view) {
 
                 for (let i = 0; i < config.MqttOptions.length; i++) {
                     Webhook.mqtt.addConfig(config.MqttOptions[i]);
+                }
+
+                for (let i = 0; i < config.TestOptions.length; i++) {
+                    Webhook.tester.addConfig(config.TestOptions[i]);
                 }
             });
 

--- a/Jellyfin.Plugin.Webhook/Tester/TestController.cs
+++ b/Jellyfin.Plugin.Webhook/Tester/TestController.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jellyfin.Extensions.Json;
+using Jellyfin.Plugin.Webhook.Destinations;
+using Jellyfin.Plugin.Webhook.Helpers;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.Webhook.Tester
+{
+    /// <summary>
+    /// API endpoints to test webhooks.
+    /// </summary>
+    [ApiController]
+    [Route("Webhook")]
+    [Authorize]
+    public class TestController : ControllerBase
+    {
+        private readonly IServerApplicationHost _applicationHost;
+        private readonly ILogger<WebhookSender> _logger;
+        private readonly IWebhookSender _webhookSender;
+        private static readonly JsonSerializerOptions _jsonIndentedOptions = new JsonSerializerOptions(JsonDefaults.Options)
+        {
+            WriteIndented = true
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestController"/> class.
+        /// </summary>
+        /// <param name="applicationHost">The application host.</param>
+        /// <param name="logger">The logger.</param>
+        /// <param name="webhookSender">The webhook sender used to send test notifications.</param>
+        public TestController(IServerApplicationHost applicationHost, ILogger<WebhookSender> logger, IWebhookSender webhookSender)
+        {
+            _applicationHost = applicationHost;
+            _logger = logger;
+            _webhookSender = webhookSender;
+        }
+
+        /// <summary>
+        /// API endpoint to test webhooks.
+        /// </summary>
+        /// <param name="testWebhooksDto">Contains the data for testing the webhooks.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [HttpPost("Test")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult> TestWebhooks([FromBody] TestWebhooksDto testWebhooksDto)
+        {
+            NotificationType notificationType = testWebhooksDto.NotificationType;
+            string? itemTypeString = testWebhooksDto.ItemType;
+            string? testData64 = testWebhooksDto.TestData;
+
+            // Get ItemType from string
+            Type? itemType;
+            switch (itemTypeString)
+            {
+                case "Movie":
+                    itemType = typeof(Movie);
+                    break;
+                case "Episode":
+                    itemType = typeof(Episode);
+                    break;
+                case "Season":
+                    itemType = typeof(Season);
+                    break;
+                case "Series":
+                    itemType = typeof(Series);
+                    break;
+                case "Album":
+                    itemType = typeof(MusicAlbum);
+                    break;
+                case "Song":
+                    itemType = typeof(Audio);
+                    break;
+                case "Video":
+                    itemType = typeof(Video);
+                    break;
+                default:
+                    itemType = null;
+                    break;
+            }
+
+            // Create base data object with notification type and item type
+            var dataObject = DataObjectHelpers.GetBaseDataObject(_applicationHost, notificationType);
+            dataObject["ItemType"] = itemType?.Name ?? "None";
+
+            // If test data is provided, decode it from Base64 and merge it into the data object. It will override the base data if there are any key conflicts.
+            if (!string.IsNullOrEmpty(testData64))
+            {
+                try
+                {
+                    string testDataJson = HandlebarsFunctionHelpers.Base64Decode(testData64);
+                    var testData = JsonSerializer.Deserialize<Dictionary<string, object>>(testDataJson) ?? [];
+                    foreach (var (key, value) in testData)
+                    {
+                        dataObject[key] = value;
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning("Invalid test data: {Message}", ex.Message);
+                    return BadRequest($"Invalid test data: {ex.Message}");
+                }
+            }
+
+            // Log the final data object that will be sent with the webhook for debugging
+            string prettyJson = JsonSerializer.Serialize(dataObject, _jsonIndentedOptions);
+            _logger.LogDebug("Testing webhooks with test data: \n{PrettyJson}", prettyJson);
+
+            // Send the notification
+            await _webhookSender.SendNotification(notificationType, dataObject, itemType).ConfigureAwait(false);
+
+            return Ok();
+        }
+    }
+}

--- a/Jellyfin.Plugin.Webhook/Tester/TestOption.cs
+++ b/Jellyfin.Plugin.Webhook/Tester/TestOption.cs
@@ -1,0 +1,25 @@
+﻿using Jellyfin.Plugin.Webhook.Destinations;
+
+namespace Jellyfin.Plugin.Webhook.Tester
+{
+    /// <summary>
+    /// Configuration for testing webhooks.
+    /// </summary>
+    public class TestOption
+    {
+        /// <summary>
+        /// Gets or sets the notification type.
+        /// </summary>
+        public NotificationType NotificationType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the item type.
+        /// </summary>
+        public string? ItemType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the test data.
+        /// </summary>
+        public string? TestData { get; set; }
+    }
+}

--- a/Jellyfin.Plugin.Webhook/Tester/TestWebhooksDto.cs
+++ b/Jellyfin.Plugin.Webhook/Tester/TestWebhooksDto.cs
@@ -1,0 +1,25 @@
+﻿using Jellyfin.Plugin.Webhook.Destinations;
+
+namespace Jellyfin.Plugin.Webhook.Tester
+{
+    /// <summary>
+    /// Configuration for testing webhooks.
+    /// </summary>
+    public class TestWebhooksDto
+    {
+        /// <summary>
+        /// Gets or sets the notification type.
+        /// </summary>
+        public required NotificationType NotificationType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the item type.
+        /// </summary>
+        public string? ItemType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the test data.
+        /// </summary>
+        public string? TestData { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,20 @@ Change your `logging.json` file to output `debug` logs for `Jellyfin.Plugin.Webh
         }
 
 ```
+At the bottom of the configuration page, you can make a test notification for each notification type and item type. This will send a simulated notification to the configured webhooks with the provided test data. The test data is a JSON object that contains all the variables used by your handlebars template.
 
+Example test data for a movie added notification:
+```json
+{
+  "Timestamp": "2026-04-30T15:46:39.5078129-06:00",
+  "Name": "Spirited Away",
+  "Overview": "A young girl, Chihiro, becomes trapped in a strange new world of spirits. When her parents undergo a mysterious transformation, she must call upon the courage she never knew she had to free her family.",
+  "ItemId": "4e19c34d-da84-d3eb-8952-8a246315ee8a",
+  "Year": 2001,
+  "Provider_tmdb": "129",
+  "Provider_imdb": "tt0245429"
+}
+```
 
 ## Documentation:
 Use [Handlebars](https://handlebarsjs.com/guide/) templating engine to format notifications however you wish.


### PR DESCRIPTION
At the bottom of the configuration page, you can make a test notification for each notification type and item type. This will send a simulated notification to the configured webhooks with the provided test data. The test data is a JSON object that contains all the variables used by your handlebars template.

It works by creating an api controller and endpoint called "TestWebhooks" that calls the "SendNotification()" method directly instead of from an event triggering. It will send a notification of the type given along with a dataObject that is built from the user's test data json.

There is a new "Add Test" button:
<img width="934" height="611" alt="image" src="https://github.com/user-attachments/assets/181f4fc9-9e1e-4b36-bddb-5597ab9dd078" />

which adds a new section for a test. There is a NotificationType and ItemType dropdown menu and a json text box prefilled with default values for all the variables the handlebars may use:
<img width="1381" height="1497" alt="image" src="https://github.com/user-attachments/assets/6f82585c-8266-4c6c-aba5-9648a6895e74" />

Heres an example of simulating adding the movie "Spirited Away":
<img width="1356" height="898" alt="image" src="https://github.com/user-attachments/assets/562b5644-18cb-4deb-b535-bbaf1db1fba5" />

This allows the user to rapidly test their webhook configs without actually adding new movies, locking out users, etc.
You can also have multiple tests for different notification types.

For #29