### PR TITLE
Fix color formatting in Discord template

### DIFF
--- a/Jellyfin.Plugin.Webhook/Templates/Discord.handlebars
+++ b/Jellyfin.Plugin.Webhook/Templates/Discord.handlebars
@@ -4,7 +4,7 @@
     "username": "{{BotUsername}}",
     "embeds": [
         {
-            "color": "{{EmbedColor}}",
+            "color": {{EmbedColor}},
             "footer": {
                 "text": "From {{{ServerName}}}",
                 "icon_url": "{{AvatarUrl}}"


### PR DESCRIPTION
To satisfy strict JSON and Discord API standards, the quotes must be removed.