### PR TITLE
Add Ntfy webhook preset

### DIFF
--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.html
@@ -23,6 +23,9 @@
             <button id="btnAddGeneric" is="emby-button" type="button" class="raised button block">
                 <span>Add Generic Destination</span>
             </button>
+            <button id="btnAddNtfy" is="emby-button" type="button" class="raised button block">
+                <span>Add Ntfy Destination</span>
+            </button>
             <button id="btnAddGenericForm" is="emby-button" type="button" class="raised button block">
                 <span>Add Generic Form Destination</span>
             </button>

--- a/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
+++ b/Jellyfin.Plugin.Webhook/Configuration/Web/config.js
@@ -329,6 +329,43 @@ export default function (view) {
                 element.querySelector("[data-name=field-wrapper]").appendChild(template);
             }
         },
+        ntfy: {
+            btnAdd: document.querySelector("#btnAddNtfy"),
+            defaultTemplate: `{
+    "topic": "{{{NtfyTopic}}}",
+    "title": "{{json_encode ServerName}} - {{json_encode NotificationType}}",
+    "message": "{{#if_exist Name}}{{json_encode Name}}{{else}}{{json_encode NotificationType}}{{/if_exist}}{{#if_exist NotificationUsername}}\\nUser: {{json_encode NotificationUsername}}{{/if_exist}}",
+    "click": "{{{ServerUrl}}}web/#/details?id={{{ItemId}}}"
+}`,
+            defaultConfig: function () {
+                return {
+                    WebhookName: "Ntfy",
+                    WebhookUri: "https://ntfy.sh",
+                    EnableWebhook: true,
+                    TrimWhitespace: true,
+                    Template: Webhook.utoa(Webhook.ntfy.defaultTemplate),
+                    Headers: [
+                        {
+                            Key: "Content-Type",
+                            Value: "application/json"
+                        },
+                        {
+                            Key: "X-Markdown",
+                            Value: "true"
+                        }
+                    ],
+                    Fields: [
+                        {
+                            Key: "NtfyTopic",
+                            Value: "jellyfin"
+                        }
+                    ]
+                };
+            },
+            addConfig: function () {
+                Webhook.generic.addConfig(Webhook.ntfy.defaultConfig());
+            }
+        },
         genericForm: {
             btnAdd: document.querySelector("#btnAddGenericForm"),
             template: document.querySelector("#template-generic-form"),
@@ -627,6 +664,7 @@ export default function (view) {
             // Add click handlers
             Webhook.discord.btnAdd.addEventListener("click", Webhook.discord.addConfig);
             Webhook.generic.btnAdd.addEventListener("click", Webhook.generic.addConfig);
+            Webhook.ntfy.btnAdd.addEventListener("click", Webhook.ntfy.addConfig);
             Webhook.genericForm.btnAdd.addEventListener("click", Webhook.genericForm.addConfig);
             Webhook.gotify.btnAdd.addEventListener("click", Webhook.gotify.addConfig);
             Webhook.pushbullet.btnAdd.addEventListener("click", Webhook.pushbullet.addConfig);

--- a/Jellyfin.Plugin.Webhook/Templates/README.md
+++ b/Jellyfin.Plugin.Webhook/Templates/README.md
@@ -1,5 +1,7 @@
 ## Templates
 ### Ntfy
+The configuration page includes an **Add Ntfy Destination** button that creates a pre-filled Generic destination.
+
 Webhook URL:
 ```
 https://ntfy.sh
@@ -7,6 +9,23 @@ https://ntfy.sh
 #or
 
 https://yourntfyurl.tld
+```
+
+Use the ntfy root URL, not a topic URL. The default preset sends JSON and uses a `NtfyTopic` field with the value `jellyfin`.
+
+Required request headers:
+```
+Key:
+Content-Type
+
+Value:
+application/json
+
+Key:
+X-Markdown
+
+Value:
+true
 ```
 
 If your ntfy needs authorization headers then add a request header as follows:


### PR DESCRIPTION
This adds an Ntfy button that creates a preconfigured Generic webhook destination.

It uses the existing Generic webhook sender rather than adding a new backend destination.

It sets the JSON content type, markdown header, default topic field, and ntfy.sh URL.

Build tested with `dotnet build Jellyfin.Plugin.Webhook.sln`.

Closes #355.